### PR TITLE
[WIP] 開発者デバッグ用画面・機能の追加

### DIFF
--- a/packages/client/src/game/state.ts
+++ b/packages/client/src/game/state.ts
@@ -1,7 +1,7 @@
 import type { GameState, Position, Tile, MatchState } from '@mahjong/shared';
 import { TURN_ORDER, initMatchState } from '@mahjong/shared';
 import { createDeck, shuffleDeck, sortHand } from '@mahjong/shared';
-import { isAgari, isTenpai } from '@mahjong/shared';
+import { calcShanten, isAgari, isTenpai } from '@mahjong/shared';
 import { detectYaku, hasValidYaku } from '@mahjong/shared';
 import { calcScore } from '@mahjong/shared';
 import { getParent } from '@mahjong/shared';
@@ -325,4 +325,58 @@ export function declareRon(state: GameState): GameState {
 export function cancelRon(state: GameState): GameState {
   if (state.phase !== 'waitingRon' || !state.waitingRon) return state;
   return nextState({ ...state, waitingRon: null }, state.currentTurn);
+}
+
+// ─── [デバッグ用] 指定シャンテン数の配牌で初期化 ────────
+// targetShanten: 0=聴牌, 1=1向聴, 2=2向聴, -1=ランダム(制約なし)
+// 条件を満たす手牌が生成されるまで最大100回リトライする
+export function initGameStateWithShanten(targetShanten: number, match?: MatchState): GameState {
+  if (targetShanten < 0) return initGameState(match);
+  for (let i = 0; i < 100; i++) {
+    const state = initGameState(match);
+    if (calcShanten(state.players['player'].hand) === targetShanten) return state;
+  }
+  return initGameState(match);
+}
+
+// ─── [デバッグ用] 指定手牌で初期化 ─────────────────────
+// hand: プレイヤーの初期手牌 (13枚)。残りは山から配布される
+export function initGameStateWithHand(hand: Tile[], match?: MatchState): GameState {
+  const currentMatch = match ?? initMatchState();
+  const handUids = new Set(hand.map(t => t.uid));
+
+  // 指定手牌を除いた残りのデッキをシャッフル
+  const remaining = shuffleDeck(createDeck().filter(t => !handUids.has(t.uid)));
+  let idx = 0;
+
+  const parentPos = getParent(currentMatch.round);
+  const players = {} as GameState['players'];
+  for (const pos of TURN_ORDER) {
+    if (pos === 'player') {
+      players[pos] = { position: pos, hand: sortHand([...hand]), discards: [] };
+    } else {
+      players[pos] = { position: pos, hand: remaining.slice(idx, idx + 13), discards: [] };
+      idx += 13;
+    }
+  }
+
+  const wall = remaining.slice(idx);
+  const drawnTile = wall.shift()!;
+  const doraTile = wall.pop()!;
+  const riichi: GameState['riichi'] = { player: false, simo: false, toimen: false, kami: false };
+
+  return {
+    wall,
+    players,
+    drawnTile,
+    selectedIndex: null,
+    phase: parentPos === 'player' ? 'playerTurn' : 'cpuTurn',
+    currentTurn: parentPos,
+    agariInfo: null,
+    doraTile,
+    riichi,
+    match: currentMatch,
+    playerNames: { player: 'あなた', simo: 'CPU南', toimen: 'CPU西', kami: 'CPU北' },
+    waitingRon: null,
+  };
 }

--- a/packages/client/src/game/state.ts
+++ b/packages/client/src/game/state.ts
@@ -339,6 +339,88 @@ export function initGameStateWithShanten(targetShanten: number, match?: MatchSta
   return initGameState(match);
 }
 
+// ─── [デバッグ用] CPU が指定UID の牌を捨てる ───────────
+// cpuDrawAndDiscard と同じ流れだが、ランダム捨てを discardUid 指定に変える
+// discardUid が -1 または見つからない場合はランダム捨て
+export function cpuDrawAndDiscardAt(state: GameState, discardUid: number): GameState {
+  if (state.phase !== 'cpuTurn') return state;
+
+  const pos = state.currentTurn;
+
+  if (state.wall.length === 0) {
+    return { ...state, phase: 'ryukyoku', drawnTile: null };
+  }
+
+  const [drawn, ...restWall] = state.wall;
+  const cpuPlayer = state.players[pos];
+
+  // ツモ和了チェック
+  const cpuFullHand = [...cpuPlayer.hand, drawn];
+  if (isAgari(cpuFullHand)) {
+    const isParent = getParent(state.match.round) === pos;
+    const yakuList  = detectYaku(cpuFullHand, true, false, state.doraTile, pos);
+    const scoreResult = calcScore(yakuList, cpuFullHand, true, isParent);
+    return {
+      ...state,
+      wall: restWall,
+      phase: 'agari',
+      agariInfo: {
+        winner: pos,
+        tile: drawn,
+        isTsumo: true,
+        yakuList,
+        han: scoreResult.han,
+        fu: scoreResult.fu,
+        score: scoreResult.score,
+        scoreDetail: scoreResult.scoreDetail,
+      },
+    };
+  }
+
+  // 指定 UID の牌を捨てる (見つからなければランダム)
+  const fullHand = cpuFullHand; // 14枚
+  const specifiedIdx = discardUid >= 0 ? fullHand.findIndex(t => t.uid === discardUid) : -1;
+  const discardIdx = specifiedIdx >= 0 ? specifiedIdx : Math.floor(Math.random() * fullHand.length);
+  const discarded = fullHand[discardIdx];
+  const newHand = fullHand.filter((_, i) => i !== discardIdx);
+
+  const newPlayers: GameState['players'] = {
+    ...state.players,
+    [pos]: {
+      ...cpuPlayer,
+      hand: newHand,
+      discards: [...cpuPlayer.discards, discarded],
+    },
+  };
+
+  const afterDiscard: GameState = {
+    ...state,
+    players: newPlayers,
+    wall: restWall,
+    drawnTile: null,
+    selectedIndex: null,
+  };
+
+  // プレイヤーのロン確認
+  const playerHand = state.players['player'].hand;
+  const playerFullHand = [...playerHand, discarded];
+  if (isAgari(playerFullHand)) {
+    const isRiichi = state.riichi['player'];
+    const yakuList = detectYaku(playerFullHand, false, isRiichi, state.doraTile, 'player');
+    if (hasValidYaku(yakuList)) {
+      const nextPos = nextTurn(pos);
+      return {
+        ...afterDiscard,
+        phase: 'waitingRon',
+        waitingRon: { discarder: pos, tile: discarded, candidates: ['player'] },
+        currentTurn: nextPos,
+      };
+    }
+  }
+
+  return nextState(afterDiscard, nextTurn(pos));
+}
+
 // ─── [デバッグ用] 指定手牌で初期化 ─────────────────────
 // hand: プレイヤーの初期手牌 (13枚)。残りは山から配布される
 export function initGameStateWithHand(hand: Tile[], match?: MatchState): GameState {

--- a/packages/client/src/game/state.ts
+++ b/packages/client/src/game/state.ts
@@ -443,7 +443,7 @@ export function initGameStateWithHand(hand: Tile[], match?: MatchState): GameSta
   }
 
   const wall = remaining.slice(idx);
-  const drawnTile = wall.shift()!;
+  const drawnTile = parentPos === 'player' ? wall.shift()! : null;
   const doraTile = wall.pop()!;
   const riichi: GameState['riichi'] = { player: false, simo: false, toimen: false, kami: false };
 

--- a/packages/client/src/game/state.ts
+++ b/packages/client/src/game/state.ts
@@ -443,7 +443,7 @@ export function initGameStateWithHand(hand: Tile[], match?: MatchState): GameSta
   }
 
   const wall = remaining.slice(idx);
-  const drawnTile = parentPos === 'player' ? wall.shift()! : null;
+  const drawnTile = wall.shift()!;
   const doraTile = wall.pop()!;
   const riichi: GameState['riichi'] = { player: false, simo: false, toimen: false, kami: false };
 

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,6 +1,7 @@
 import './style.css';
 import { initGameState, cpuDrawAndDiscard } from './game/state';
 import { renderBoard } from './ui/board';
+import { renderBoardDebug } from './ui/board-debug';
 import { renderLobby, renderWaiting, renderConnectionError } from './ui/lobby';
 import { WsClient } from './net/wsClient';
 import { applyRoundResult } from '@mahjong/shared';
@@ -11,12 +12,25 @@ import type { GameState, Position } from '@mahjong/shared';
 const WS_URL = import.meta.env.VITE_WS_URL ?? 'ws://localhost:3000';
 const CPU_DELAY = 600;
 
+// ─── デバッグモード: URL ハッシュ #debug でのみ有効 ──────
+const isDebugMode = window.location.hash === '#debug';
+
 // ─── 状態 ──────────────────────────────────────────
 let gameState: GameState = initGameState();
 let cpuTimer: ReturnType<typeof setTimeout> | null = null;
 let wsClient: WsClient | null = null;
 let myPosition: Position | null = null;   // オンラインモード時の自座席
 let isOnline = false;
+
+// ─── ボード描画 (通常/デバッグを一元管理) ───────────────
+function renderCurrentBoard(): void {
+  const updateFn = isOnline ? onlineUpdate : update;
+  if (isDebugMode) {
+    renderBoardDebug(gameState, updateFn, restart, nextRound, debugRestart, myPosition);
+  } else {
+    renderBoard(gameState, updateFn, restart, nextRound, myPosition);
+  }
+}
 
 // ─── オフラインモード ────────────────────────────────
 
@@ -26,7 +40,7 @@ function clearCpuTimer(): void {
 
 function update(newState: GameState): void {
   gameState = newState;
-  renderBoard(gameState, isOnline ? onlineUpdate : update, restart, nextRound, myPosition);
+  renderCurrentBoard();
   if (!isOnline) scheduleCpuIfNeeded();
 }
 
@@ -70,11 +84,17 @@ function restart(): void {
 // 牌の選択など「ローカルのみ」の状態変化もここで再レンダリングする
 function onlineUpdate(newState: GameState): void {
   gameState = newState;
-  renderBoard(gameState, onlineUpdate, restart, nextRound, myPosition);
+  renderCurrentBoard();
 }
 
 export function sendAction(msg: Parameters<WsClient['send']>[0]): void {
   wsClient?.send(msg);
+}
+
+// ─── [デバッグ用] 任意の GameState で再スタート ──────────
+function debugRestart(newState: GameState): void {
+  clearCpuTimer();
+  update(newState);
 }
 
 function startOnline(playerName: string, roomId: string): void {
@@ -90,7 +110,7 @@ function startOnline(playerName: string, roomId: string): void {
     },
     onStateUpdate: (state) => {
       gameState = state;
-      renderBoard(gameState, onlineUpdate, restart, nextRound, myPosition);
+      renderCurrentBoard();
     },
     onError: (message) => {
       renderConnectionError(message, () => {
@@ -129,4 +149,13 @@ function showLobby(): void {
 }
 
 // ─── 初期化 ──────────────────────────────────────────
-showLobby();
+if (isDebugMode) {
+  // デバッグモード時はロビーをスキップして即ゲーム開始
+  const banner = document.createElement('div');
+  banner.className = 'debug-mode-banner';
+  banner.textContent = '🔧 DEBUG MODE — 開発者専用画面';
+  document.body.insertBefore(banner, document.getElementById('app'));
+  update(initGameState(initMatchState()));
+} else {
+  showLobby();
+}

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -23,7 +23,7 @@ let debugCpuMode: DebugCpuMode = 'auto-discard';
 export function getDebugCpuMode(): DebugCpuMode { return debugCpuMode; }
 export function setDebugCpuMode(mode: DebugCpuMode): void {
   debugCpuMode = mode;
-  // 手動モードから自動モードに切り替えた場合、保留中のターンを再開倒す
+  // 手動モードから自動モードに切り替えた場合、保留中のターンを再開する
   if (mode !== 'manual') scheduleCpuIfNeeded();
   renderCurrentBoard();
 }

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -12,8 +12,9 @@ import type { GameState, Position } from '@mahjong/shared';
 const WS_URL = import.meta.env.VITE_WS_URL ?? 'ws://localhost:3000';
 const CPU_DELAY = 600;
 
-// ─── デバッグモード: URL ハッシュ #debug でのみ有効 ──────
-const isDebugMode = window.location.hash === '#debug';
+// ─── デバッグモード: 開発環境かつ URL ハッシュ #debug でのみ有効 ──
+// 本番ビルド時は import.meta.env.DEV が false に置換されるため常に無効
+const isDebugMode = import.meta.env.DEV && window.location.hash === '#debug';
 
 // ─── 状態 ──────────────────────────────────────────
 let gameState: GameState = initGameState();

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -2,19 +2,31 @@ import './style.css';
 import { initGameState, cpuDrawAndDiscard } from './game/state';
 import { renderBoard } from './ui/board';
 import { renderBoardDebug } from './ui/board-debug';
+import type { DebugCpuMode } from './ui/board-debug';
 import { renderLobby, renderWaiting, renderConnectionError } from './ui/lobby';
 import { WsClient } from './net/wsClient';
 import { applyRoundResult } from '@mahjong/shared';
 import { initMatchState } from '@mahjong/shared';
 import type { GameState, Position } from '@mahjong/shared';
 
-// ─── 設定 ──────────────────────────────────────────
+// ─── 設定 ──────────────────────────────────────────────────
 const WS_URL = import.meta.env.VITE_WS_URL ?? 'ws://localhost:3000';
 const CPU_DELAY = 600;
 
-// ─── デバッグモード: 開発環境かつ URL ハッシュ #debug でのみ有効 ──
+// ─── デバッグモード: 開発環境かつ URL ハッシュ #debug でのみ有効 ────
 // 本番ビルド時は import.meta.env.DEV が false に置換されるため常に無効
 const isDebugMode = import.meta.env.DEV && window.location.hash === '#debug';
+
+// ─── CPU 操作モード (デバッグ時のみ使用) ────────────────────
+let debugCpuMode: DebugCpuMode = 'auto-discard';
+
+export function getDebugCpuMode(): DebugCpuMode { return debugCpuMode; }
+export function setDebugCpuMode(mode: DebugCpuMode): void {
+  debugCpuMode = mode;
+  // 手動モードから自動モードに切り替えた場合、保留中のターンを再開倒す
+  if (mode !== 'manual') scheduleCpuIfNeeded();
+  renderCurrentBoard();
+}
 
 // ─── 状態 ──────────────────────────────────────────
 let gameState: GameState = initGameState();
@@ -27,7 +39,10 @@ let isOnline = false;
 function renderCurrentBoard(): void {
   const updateFn = isOnline ? onlineUpdate : update;
   if (isDebugMode) {
-    renderBoardDebug(gameState, updateFn, restart, nextRound, debugRestart, myPosition);
+    renderBoardDebug(
+      gameState, updateFn, restart, nextRound, debugRestart,
+      debugCpuMode, setDebugCpuMode, myPosition,
+    );
   } else {
     renderBoard(gameState, updateFn, restart, nextRound, myPosition);
   }
@@ -48,6 +63,8 @@ function update(newState: GameState): void {
 function scheduleCpuIfNeeded(): void {
   clearCpuTimer();
   if (gameState.phase === 'cpuTurn') {
+    // デバッグ手動モード時は CPU 自動実行しない
+    if (isDebugMode && debugCpuMode === 'manual') return;
     cpuTimer = setTimeout(() => {
       cpuTimer = null;
       update(cpuDrawAndDiscard(gameState));

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -910,6 +910,20 @@ h1 {
   background: #1d4ed8;
 }
 
+.debug-btn--mode-active {
+  background: #5b21b6;
+  border-color: #a78bfa;
+  color: #ede9fe;
+  font-weight: 700;
+}
+
+.debug-subtitle {
+  font-size: 11px;
+  color: #c4b5fd;
+  margin-top: 4px;
+  margin-bottom: 2px;
+}
+
 .debug-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -792,11 +792,6 @@ h1 {
   margin-bottom: 2px;
 }
 
-.debug-subtitle {
-  font-size: 11px;
-  color: #9ca3af;
-  margin-bottom: 4px;
-}
 
 /* ─── 全プレイヤー手牌行 ─────────────────────────── */
 .debug-hand-row {

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -900,6 +900,16 @@ h1 {
   background: #047857;
 }
 
+.debug-btn--yaku {
+  background: #1e3a5f;
+  border-color: #3b82f6;
+  color: #bfdbfe;
+}
+
+.debug-btn--yaku:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
 .debug-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -740,3 +740,202 @@ h1 {
   text-align: center;
   margin: 0;
 }
+
+/* ─── デバッグモードバナー ─────────────────────────── */
+.debug-mode-banner {
+  width: 100%;
+  padding: 6px 0;
+  text-align: center;
+  background: #7c3aed;
+  color: #fff;
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: 0.05em;
+}
+
+/* ─── デバッグパネル ───────────────────────────────── */
+.debug-panel {
+  width: 100%;
+  max-width: 1400px;
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 2px solid #7c3aed;
+  border-radius: 8px;
+  padding: 12px 16px;
+  background: #1a1030;
+  color: #e0d0ff;
+  font-size: 12px;
+}
+
+.debug-header {
+  font-size: 14px;
+  font-weight: bold;
+  color: #c084fc;
+  letter-spacing: 0.1em;
+  border-bottom: 1px solid #7c3aed;
+  padding-bottom: 6px;
+}
+
+/* ─── デバッグセクション ──────────────────────────── */
+.debug-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.debug-section-title {
+  font-size: 12px;
+  font-weight: bold;
+  color: #a78bfa;
+  margin-bottom: 2px;
+}
+
+.debug-subtitle {
+  font-size: 11px;
+  color: #9ca3af;
+  margin-bottom: 4px;
+}
+
+/* ─── 全プレイヤー手牌行 ─────────────────────────── */
+.debug-hand-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.debug-hand-label {
+  min-width: 60px;
+  font-size: 11px;
+  color: #c4b5fd;
+  white-space: nowrap;
+}
+
+.debug-hand-tiles {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+.debug-shanten {
+  font-size: 11px;
+  color: #86efac;
+  margin-left: 4px;
+  white-space: nowrap;
+}
+
+/* ─── デバッグ用牌画像 ───────────────────────────── */
+.debug-tile {
+  width: 22px;
+  height: auto;
+  display: inline-block;
+}
+
+.debug-tile--wall,
+.debug-tile--picker {
+  cursor: pointer;
+  transition: opacity 0.1s;
+}
+
+.debug-tile--wall:hover,
+.debug-tile--picker:hover {
+  opacity: 0.75;
+}
+
+.debug-tile--next {
+  outline: 2px solid #f0c040;
+  border-radius: 2px;
+}
+
+.debug-tile--picker--selected {
+  outline: 2px solid #4ade80;
+  border-radius: 2px;
+  opacity: 0.85;
+}
+
+.debug-tile--thumb {
+  width: 20px;
+  height: auto;
+}
+
+/* ─── ツモ山グリッド ────────────────────────────── */
+.debug-wall-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+/* ─── ボタン行 ───────────────────────────────────── */
+.debug-btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.debug-btn {
+  padding: 4px 10px;
+  font-size: 12px;
+  background: #4c1d95;
+  color: #e9d5ff;
+  border: 1px solid #7c3aed;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.debug-btn:hover:not(:disabled) {
+  background: #6d28d9;
+}
+
+.debug-btn--apply {
+  background: #065f46;
+  border-color: #059669;
+  color: #d1fae5;
+}
+
+.debug-btn--apply:hover:not(:disabled) {
+  background: #047857;
+}
+
+.debug-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ─── 手牌ピッカー ───────────────────────────────── */
+.debug-hand-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  border-top: 1px dashed #4c1d95;
+  padding-top: 8px;
+}
+
+.debug-selected-area {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 3px;
+  min-height: 28px;
+}
+
+.debug-selected-count {
+  font-size: 11px;
+  color: #c4b5fd;
+  margin-right: 6px;
+}
+
+.debug-picker-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  max-height: 120px;
+  overflow-y: auto;
+  border: 1px solid #4c1d95;
+  border-radius: 4px;
+  padding: 4px;
+}

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -10,11 +10,80 @@
  * 3. 新規配牌: ランダム / シャンテン数指定 / 手牌直接指定
  */
 
-import type { GameState, Position, Tile } from '@mahjong/shared';
-import { TURN_ORDER, getTileImagePath, getTileLabel } from '@mahjong/shared';
+import type { GameState, Position, Tile, TileKind, HonorKey } from '@mahjong/shared';
+import { TURN_ORDER, getTileImagePath, getTileLabel, sortHand } from '@mahjong/shared';
 import { calcShanten } from '@mahjong/shared';
 import { renderBoard } from './board';
 import { initGameStateWithShanten, initGameStateWithHand } from '../game/state';
+
+// ─── 役プリセット定義 ─────────────────────────────────────
+interface TileSpec { kind: TileKind; number?: number; honor?: HonorKey; }
+
+const YAKU_PRESETS: { label: string; tiles: TileSpec[] }[] = [
+  {
+    label: '平和',
+    // 1m2m3m 4m5m6m 2p3p 5p6p7p 9p9p  待ち: 1p or 4p (両面)
+    tiles: [
+      { kind: 'manzu', number: 1 }, { kind: 'manzu', number: 2 }, { kind: 'manzu', number: 3 },
+      { kind: 'manzu', number: 4 }, { kind: 'manzu', number: 5 }, { kind: 'manzu', number: 6 },
+      { kind: 'pinzu', number: 2 }, { kind: 'pinzu', number: 3 },
+      { kind: 'pinzu', number: 5 }, { kind: 'pinzu', number: 6 }, { kind: 'pinzu', number: 7 },
+      { kind: 'pinzu', number: 9 }, { kind: 'pinzu', number: 9 },
+    ],
+  },
+  {
+    label: '一盃口',
+    // 1m2m3m 1m2m3m 4m5m 7p8p9p 1s1s  待ち: 3m or 6m (両面)
+    tiles: [
+      { kind: 'manzu', number: 1 }, { kind: 'manzu', number: 2 }, { kind: 'manzu', number: 3 },
+      { kind: 'manzu', number: 1 }, { kind: 'manzu', number: 2 }, { kind: 'manzu', number: 3 },
+      { kind: 'manzu', number: 4 }, { kind: 'manzu', number: 5 },
+      { kind: 'pinzu', number: 7 }, { kind: 'pinzu', number: 8 }, { kind: 'pinzu', number: 9 },
+      { kind: 'sozu', number: 1 }, { kind: 'sozu', number: 1 },
+    ],
+  },
+  {
+    label: 'ホンイツ',
+    // 1m2m3m 5m6m7m 8m9m 東東東 発発  待ち: 4m or 7m (両面)
+    tiles: [
+      { kind: 'manzu', number: 1 }, { kind: 'manzu', number: 2 }, { kind: 'manzu', number: 3 },
+      { kind: 'manzu', number: 5 }, { kind: 'manzu', number: 6 }, { kind: 'manzu', number: 7 },
+      { kind: 'manzu', number: 8 }, { kind: 'manzu', number: 9 },
+      { kind: 'tupai', honor: 'e' }, { kind: 'tupai', honor: 'e' }, { kind: 'tupai', honor: 'e' },
+      { kind: 'tupai', honor: 'no' }, { kind: 'tupai', honor: 'no' },
+    ],
+  },
+  {
+    label: 'タンヤオ',
+    // 2m3m4m 5m6m 2p3p4p 5p6p7p 8s8s  待ち: 4m or 7m (両面)
+    tiles: [
+      { kind: 'manzu', number: 2 }, { kind: 'manzu', number: 3 }, { kind: 'manzu', number: 4 },
+      { kind: 'manzu', number: 5 }, { kind: 'manzu', number: 6 },
+      { kind: 'pinzu', number: 2 }, { kind: 'pinzu', number: 3 }, { kind: 'pinzu', number: 4 },
+      { kind: 'pinzu', number: 5 }, { kind: 'pinzu', number: 6 }, { kind: 'pinzu', number: 7 },
+      { kind: 'sozu', number: 8 }, { kind: 'sozu', number: 8 },
+    ],
+  },
+];
+
+// spec に合う未使用の牌を pool から探す
+function findTilesFromPool(specs: TileSpec[], pool: Tile[]): Tile[] | null {
+  const result: Tile[] = [];
+  const usedUids = new Set<number>();
+  for (const spec of specs) {
+    const found = pool.find(
+      t =>
+        !usedUids.has(t.uid) &&
+        t.kind === spec.kind &&
+        t.number === spec.number &&
+        t.honor === spec.honor,
+    );
+    if (!found) return null;
+    usedUids.add(found.uid);
+    result.push(found);
+  }
+  return result;
+}
 
 type UpdateFn       = (s: GameState) => void;
 type RestartFn      = () => void;
@@ -112,17 +181,20 @@ function buildDebugWall(state: GameState, onUpdate: UpdateFn): HTMLElement {
   const wallGrid = document.createElement('div');
   wallGrid.className = 'debug-wall-grid';
 
-  state.wall.forEach((tile, idx) => {
+  // 表示は理牌順に並べるが、クリック時はオリジナルの wall 配列インデックスで操作する
+  const sorted = sortHand([...state.wall]);
+  sorted.forEach((tile) => {
+    const origIdx = state.wall.findIndex(t => t.uid === tile.uid);
     const img = document.createElement('img');
     img.src = getTileImagePath(tile);
     img.alt = getTileLabel(tile);
     img.draggable = false;
     img.title = `${getTileLabel(tile)} — クリックで次ツモに設定`;
     img.className =
-      'debug-tile debug-tile--wall' + (idx === 0 ? ' debug-tile--next' : '');
+      'debug-tile debug-tile--wall' + (origIdx === 0 ? ' debug-tile--next' : '');
     img.addEventListener('click', () => {
       const newWall = [...state.wall];
-      newWall.splice(idx, 1);
+      newWall.splice(origIdx, 1);
       newWall.unshift(tile);
       onUpdate({ ...state, wall: newWall });
     });
@@ -138,27 +210,32 @@ function buildDebugNewGame(state: GameState, onDebugRestart: DebugRestartFn): HT
   const section = buildSection('新規配牌');
 
   // シャンテン数指定ボタン行
-  const btnRow = document.createElement('div');
-  btnRow.className = 'debug-btn-row';
+  const shantenLabel = document.createElement('div');
+  shantenLabel.className = 'debug-subtitle';
+  shantenLabel.textContent = 'シャンテン数指定';
+  section.appendChild(shantenLabel);
 
-  const presets: { label: string; shanten: number }[] = [
+  const shantenRow = document.createElement('div');
+  shantenRow.className = 'debug-btn-row';
+
+  const shantenPresets: { label: string; shanten: number }[] = [
     { label: 'ランダム',    shanten: -1 },
     { label: '聴牌(0向聴)', shanten: 0  },
     { label: '1向聴',       shanten: 1  },
     { label: '2向聴',       shanten: 2  },
   ];
 
-  for (const { label, shanten } of presets) {
+  for (const { label, shanten } of shantenPresets) {
     const btn = document.createElement('button');
     btn.className = 'btn debug-btn';
     btn.textContent = label;
     btn.addEventListener('click', () => {
       onDebugRestart(initGameStateWithShanten(shanten, state.match));
     });
-    btnRow.appendChild(btn);
+    shantenRow.appendChild(btn);
   }
 
-  section.appendChild(btnRow);
+  section.appendChild(shantenRow);
   section.appendChild(buildHandPicker(state, onDebugRestart));
   return section;
 }
@@ -172,6 +249,16 @@ function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTML
   subTitle.className = 'debug-subtitle';
   subTitle.textContent = '手牌直接指定 — 13枚選択後に「適用」';
   container.appendChild(subTitle);
+
+  // 役プリセットボタン行
+  const yakuLabel = document.createElement('div');
+  yakuLabel.className = 'debug-subtitle';
+  yakuLabel.textContent = '役プリセット（テンパイ手牌を自動選択）';
+  container.appendChild(yakuLabel);
+
+  const yakuRow = document.createElement('div');
+  yakuRow.className = 'debug-btn-row';
+  container.appendChild(yakuRow);
 
   // 選択済み牌の表示エリア
   const selectedArea = document.createElement('div');
@@ -202,6 +289,38 @@ function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTML
   // 選択牌の管理
   const selected: Tile[] = [];
 
+  // 役プリセットボタンの生成（selected が確定してから関数参照できるよう後置）
+  const availableForPreset: Tile[] = [
+    ...state.wall,
+    ...TURN_ORDER.flatMap(pos => state.players[pos].hand),
+    ...(state.drawnTile ? [state.drawnTile] : []),
+  ];
+
+  for (const preset of YAKU_PRESETS) {
+    const btn = document.createElement('button');
+    btn.className = 'btn debug-btn debug-btn--yaku';
+    btn.textContent = preset.label;
+    btn.addEventListener('click', () => {
+      const tiles = findTilesFromPool(preset.tiles, availableForPreset);
+      if (!tiles) {
+        btn.textContent = `${preset.label} (牌不足)`;
+        return;
+      }
+      // 既存の選択をリセットしてプリセット牌を選択
+      selected.length = 0;
+      pickerGrid.querySelectorAll('.debug-tile--picker--selected').forEach(el =>
+        el.classList.remove('debug-tile--picker--selected'),
+      );
+      for (const tile of tiles) {
+        selected.push(tile);
+        const el = pickerGrid.querySelector<HTMLImageElement>(`[data-uid="${tile.uid}"]`);
+        el?.classList.add('debug-tile--picker--selected');
+      }
+      refreshSelected();
+    });
+    yakuRow.appendChild(btn);
+  }
+
   function refreshSelected(): void {
     countEl.textContent = `選択済: ${selected.length} / 13`;
     applyBtn.disabled = selected.length !== 13;
@@ -230,12 +349,12 @@ function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTML
     );
   });
 
-  // ピッカーグリッド: 現在のゲームで未使用の全牌
-  const availableTiles: Tile[] = [
+  // ピッカーグリッド: 現在のゲームで未使用の全牌（理牌順にソート）
+  const availableTiles: Tile[] = sortHand([
     ...state.wall,
     ...TURN_ORDER.flatMap(pos => state.players[pos].hand),
     ...(state.drawnTile ? [state.drawnTile] : []),
-  ];
+  ]);
 
   const pickerGrid = document.createElement('div');
   pickerGrid.className = 'debug-picker-grid';
@@ -245,6 +364,7 @@ function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTML
     img.src = getTileImagePath(tile);
     img.alt = getTileLabel(tile);
     img.className = 'debug-tile debug-tile--picker';
+    img.dataset.uid = String(tile.uid);
     img.draggable = false;
     img.title = getTileLabel(tile);
     img.addEventListener('click', () => {

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -1,0 +1,277 @@
+/**
+ * デバッグ用ボード画面
+ *
+ * - 通常のボード（renderBoard）の下にデバッグパネルを追加表示する
+ * - URL ハッシュ #debug でのみアクセス可能
+ *
+ * [デバッグパネル機能]
+ * 1. 全プレイヤーの手牌をオモテで表示（シャンテン数付き）
+ * 2. 残りツモ山を全表示。クリックした牌を次ツモに移動できる
+ * 3. 新規配牌: ランダム / シャンテン数指定 / 手牌直接指定
+ */
+
+import type { GameState, Position, Tile } from '@mahjong/shared';
+import { TURN_ORDER, getTileImagePath, getTileLabel } from '@mahjong/shared';
+import { calcShanten } from '@mahjong/shared';
+import { renderBoard } from './board';
+import { initGameStateWithShanten, initGameStateWithHand } from '../game/state';
+
+type UpdateFn       = (s: GameState) => void;
+type RestartFn      = () => void;
+type NextRoundFn    = (s: GameState) => void;
+type DebugRestartFn = (s: GameState) => void;
+
+// ─── デバッグ版レンダラー ──────────────────────────────
+export function renderBoardDebug(
+  state: GameState,
+  onUpdate: UpdateFn,
+  onRestart: RestartFn,
+  onNextRound: NextRoundFn,
+  onDebugRestart: DebugRestartFn,
+  myPosition: Position | null = null,
+): void {
+  renderBoard(state, onUpdate, onRestart, onNextRound, myPosition);
+  const app = document.getElementById('app')!;
+  app.appendChild(buildDebugPanel(state, onUpdate, onDebugRestart));
+}
+
+// ─── デバッグパネル全体 ────────────────────────────────
+function buildDebugPanel(
+  state: GameState,
+  onUpdate: UpdateFn,
+  onDebugRestart: DebugRestartFn,
+): HTMLElement {
+  const panel = document.createElement('div');
+  panel.className = 'debug-panel';
+
+  const header = document.createElement('div');
+  header.className = 'debug-header';
+  header.textContent = '🔧 DEBUG PANEL';
+  panel.appendChild(header);
+
+  panel.appendChild(buildDebugHands(state));
+  panel.appendChild(buildDebugWall(state, onUpdate));
+  panel.appendChild(buildDebugNewGame(state, onDebugRestart));
+
+  return panel;
+}
+
+// ─── セクション1: 全プレイヤー手牌（表向き）+ シャンテン数 ─
+function buildDebugHands(state: GameState): HTMLElement {
+  const section = buildSection('全プレイヤー手牌（シャンテン数）');
+
+  const posLabels: Record<Position, string> = {
+    player: 'あなた', simo: '下家', toimen: '対面', kami: '上家',
+  };
+
+  for (const pos of TURN_ORDER) {
+    const row = document.createElement('div');
+    row.className = 'debug-hand-row';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'debug-hand-label';
+    nameEl.textContent = `${state.playerNames?.[pos] ?? posLabels[pos]}:`;
+    row.appendChild(nameEl);
+
+    const tilesEl = document.createElement('div');
+    tilesEl.className = 'debug-hand-tiles';
+
+    const tiles = [...state.players[pos].hand];
+    if (pos === state.currentTurn && state.drawnTile) {
+      tiles.push(state.drawnTile);
+    }
+
+    for (const tile of tiles) {
+      const img = document.createElement('img');
+      img.src = getTileImagePath(tile);
+      img.alt = getTileLabel(tile);
+      img.className = 'debug-tile';
+      img.draggable = false;
+      tilesEl.appendChild(img);
+    }
+
+    const sh = calcShanten(tiles);
+    const shantenEl = document.createElement('span');
+    shantenEl.className = 'debug-shanten';
+    shantenEl.textContent = sh === -1 ? '和了' : sh === 0 ? '聴牌' : `${sh}向聴`;
+    tilesEl.appendChild(shantenEl);
+
+    row.appendChild(tilesEl);
+    section.appendChild(row);
+  }
+
+  return section;
+}
+
+// ─── セクション2: 残りツモ山 + 次ツモ牌選択 ─────────────
+function buildDebugWall(state: GameState, onUpdate: UpdateFn): HTMLElement {
+  const section = buildSection(
+    `残りツモ山 (${state.wall.length}枚) — 牌をクリックで次ツモに移動`,
+  );
+
+  const wallGrid = document.createElement('div');
+  wallGrid.className = 'debug-wall-grid';
+
+  state.wall.forEach((tile, idx) => {
+    const img = document.createElement('img');
+    img.src = getTileImagePath(tile);
+    img.alt = getTileLabel(tile);
+    img.draggable = false;
+    img.title = `${getTileLabel(tile)} — クリックで次ツモに設定`;
+    img.className =
+      'debug-tile debug-tile--wall' + (idx === 0 ? ' debug-tile--next' : '');
+    img.addEventListener('click', () => {
+      const newWall = [...state.wall];
+      newWall.splice(idx, 1);
+      newWall.unshift(tile);
+      onUpdate({ ...state, wall: newWall });
+    });
+    wallGrid.appendChild(img);
+  });
+
+  section.appendChild(wallGrid);
+  return section;
+}
+
+// ─── セクション3: カスタム配牌 ───────────────────────────
+function buildDebugNewGame(state: GameState, onDebugRestart: DebugRestartFn): HTMLElement {
+  const section = buildSection('新規配牌');
+
+  // シャンテン数指定ボタン行
+  const btnRow = document.createElement('div');
+  btnRow.className = 'debug-btn-row';
+
+  const presets: { label: string; shanten: number }[] = [
+    { label: 'ランダム',    shanten: -1 },
+    { label: '聴牌(0向聴)', shanten: 0  },
+    { label: '1向聴',       shanten: 1  },
+    { label: '2向聴',       shanten: 2  },
+  ];
+
+  for (const { label, shanten } of presets) {
+    const btn = document.createElement('button');
+    btn.className = 'btn debug-btn';
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      onDebugRestart(initGameStateWithShanten(shanten, state.match));
+    });
+    btnRow.appendChild(btn);
+  }
+
+  section.appendChild(btnRow);
+  section.appendChild(buildHandPicker(state, onDebugRestart));
+  return section;
+}
+
+// ─── 手牌ピッカー: 13枚を選択して適用 ──────────────────
+function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'debug-hand-picker';
+
+  const subTitle = document.createElement('div');
+  subTitle.className = 'debug-subtitle';
+  subTitle.textContent = '手牌直接指定 — 13枚選択後に「適用」';
+  container.appendChild(subTitle);
+
+  // 選択済み牌の表示エリア
+  const selectedArea = document.createElement('div');
+  selectedArea.className = 'debug-selected-area';
+  const countEl = document.createElement('span');
+  countEl.className = 'debug-selected-count';
+  countEl.textContent = '選択済: 0 / 13';
+  selectedArea.appendChild(countEl);
+  container.appendChild(selectedArea);
+
+  // 操作ボタン行
+  const ctrlRow = document.createElement('div');
+  ctrlRow.className = 'debug-btn-row';
+
+  const applyBtn = document.createElement('button');
+  applyBtn.className = 'btn debug-btn debug-btn--apply';
+  applyBtn.textContent = '手牌を適用して開始';
+  applyBtn.disabled = true;
+
+  const resetBtn = document.createElement('button');
+  resetBtn.className = 'btn debug-btn';
+  resetBtn.textContent = '選択リセット';
+
+  ctrlRow.appendChild(applyBtn);
+  ctrlRow.appendChild(resetBtn);
+  container.appendChild(ctrlRow);
+
+  // 選択牌の管理
+  const selected: Tile[] = [];
+
+  function refreshSelected(): void {
+    countEl.textContent = `選択済: ${selected.length} / 13`;
+    applyBtn.disabled = selected.length !== 13;
+    selectedArea.querySelectorAll('img').forEach(el => el.remove());
+    for (const tile of selected) {
+      const img = document.createElement('img');
+      img.src = getTileImagePath(tile);
+      img.alt = getTileLabel(tile);
+      img.className = 'debug-tile debug-tile--thumb';
+      img.draggable = false;
+      selectedArea.appendChild(img);
+    }
+  }
+
+  applyBtn.addEventListener('click', () => {
+    if (selected.length === 13) {
+      onDebugRestart(initGameStateWithHand([...selected], state.match));
+    }
+  });
+
+  resetBtn.addEventListener('click', () => {
+    selected.length = 0;
+    refreshSelected();
+    pickerGrid.querySelectorAll('.debug-tile--picker--selected').forEach(el =>
+      el.classList.remove('debug-tile--picker--selected'),
+    );
+  });
+
+  // ピッカーグリッド: 現在のゲームで未使用の全牌
+  const availableTiles: Tile[] = [
+    ...state.wall,
+    ...TURN_ORDER.flatMap(pos => state.players[pos].hand),
+    ...(state.drawnTile ? [state.drawnTile] : []),
+  ];
+
+  const pickerGrid = document.createElement('div');
+  pickerGrid.className = 'debug-picker-grid';
+
+  for (const tile of availableTiles) {
+    const img = document.createElement('img');
+    img.src = getTileImagePath(tile);
+    img.alt = getTileLabel(tile);
+    img.className = 'debug-tile debug-tile--picker';
+    img.draggable = false;
+    img.title = getTileLabel(tile);
+    img.addEventListener('click', () => {
+      if (img.classList.contains('debug-tile--picker--selected')) {
+        const i = selected.findIndex(t => t.uid === tile.uid);
+        if (i !== -1) selected.splice(i, 1);
+        img.classList.remove('debug-tile--picker--selected');
+      } else if (selected.length < 13) {
+        selected.push(tile);
+        img.classList.add('debug-tile--picker--selected');
+      }
+      refreshSelected();
+    });
+    pickerGrid.appendChild(img);
+  }
+
+  container.appendChild(pickerGrid);
+  return container;
+}
+
+// ─── ユーティリティ: セクション要素の生成 ────────────────
+function buildSection(title: string): HTMLElement {
+  const section = document.createElement('div');
+  section.className = 'debug-section';
+  const h = document.createElement('div');
+  h.className = 'debug-section-title';
+  h.textContent = title;
+  section.appendChild(h);
+  return section;
+}

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -14,7 +14,11 @@ import type { GameState, Position, Tile, TileKind, HonorKey } from '@mahjong/sha
 import { TURN_ORDER, getTileImagePath, getTileLabel, sortHand } from '@mahjong/shared';
 import { calcShanten } from '@mahjong/shared';
 import { renderBoard } from './board';
-import { initGameStateWithShanten, initGameStateWithHand } from '../game/state';
+import { initGameStateWithShanten, initGameStateWithHand, cpuDrawAndDiscardAt } from '../game/state';
+
+// CPU 操作モード
+export type DebugCpuMode = 'auto-discard' | 'manual' | 'ai';
+type SetCpuModeFn = (mode: DebugCpuMode) => void;
 
 // ─── 役プリセット定義 ─────────────────────────────────────
 interface TileSpec { kind: TileKind; number?: number; honor?: HonorKey; }
@@ -97,11 +101,13 @@ export function renderBoardDebug(
   onRestart: RestartFn,
   onNextRound: NextRoundFn,
   onDebugRestart: DebugRestartFn,
+  cpuMode: DebugCpuMode,
+  setCpuMode: SetCpuModeFn,
   myPosition: Position | null = null,
 ): void {
   renderBoard(state, onUpdate, onRestart, onNextRound, myPosition);
   const app = document.getElementById('app')!;
-  app.appendChild(buildDebugPanel(state, onUpdate, onDebugRestart));
+  app.appendChild(buildDebugPanel(state, onUpdate, onDebugRestart, cpuMode, setCpuMode));
 }
 
 // ─── デバッグパネル全体 ────────────────────────────────
@@ -109,6 +115,8 @@ function buildDebugPanel(
   state: GameState,
   onUpdate: UpdateFn,
   onDebugRestart: DebugRestartFn,
+  cpuMode: DebugCpuMode,
+  setCpuMode: SetCpuModeFn,
 ): HTMLElement {
   const panel = document.createElement('div');
   panel.className = 'debug-panel';
@@ -118,11 +126,78 @@ function buildDebugPanel(
   header.textContent = '🔧 DEBUG PANEL';
   panel.appendChild(header);
 
+  panel.appendChild(buildDebugCpuMode(state, onUpdate, cpuMode, setCpuMode));
   panel.appendChild(buildDebugHands(state));
   panel.appendChild(buildDebugWall(state, onUpdate));
   panel.appendChild(buildDebugNewGame(state, onDebugRestart));
 
   return panel;
+}
+
+// ─── CPU 操作モードセレクター + 手動捕作 UI ────────────────
+function buildDebugCpuMode(
+  state: GameState,
+  onUpdate: UpdateFn,
+  cpuMode: DebugCpuMode,
+  setCpuMode: SetCpuModeFn,
+): HTMLElement {
+  const section = buildSection('CPU 操作モード');
+
+  const modeRow = document.createElement('div');
+  modeRow.className = 'debug-btn-row';
+
+  const modes: { mode: DebugCpuMode; label: string }[] = [
+    { mode: 'auto-discard', label: '自動ツモ切り' },
+    { mode: 'manual',       label: '手動操作' },
+    { mode: 'ai',           label: 'AI操作' },
+  ];
+
+  for (const { mode, label } of modes) {
+    const btn = document.createElement('button');
+    btn.className = 'btn debug-btn' + (cpuMode === mode ? ' debug-btn--mode-active' : '');
+    btn.textContent = label;
+    btn.addEventListener('click', () => setCpuMode(mode));
+    modeRow.appendChild(btn);
+  }
+  section.appendChild(modeRow);
+
+  // 手動操作モード且つ cpuTurn の時: 当該 CPU の捕作 UI を表示
+  if (cpuMode === 'manual' && state.phase === 'cpuTurn') {
+    const pos = state.currentTurn;
+    const posLabels: Record<Position, string> = {
+      player: 'あなた', simo: '下家', toimen: '対面', kami: '上家',
+    };
+    const cpuName = state.playerNames?.[pos] ?? posLabels[pos];
+
+    const manualTitle = document.createElement('div');
+    manualTitle.className = 'debug-subtitle';
+    manualTitle.textContent = `${cpuName}の捕作牌を選択 (13枚の手牌 + 次ツモ牌):`;
+    section.appendChild(manualTitle);
+
+    const handRow = document.createElement('div');
+    handRow.className = 'debug-hand-tiles';
+
+    // CPU手牌（13枚）+ 山の次牌（1枚）を理牌順で表示
+    const cpuHand = sortHand([...state.players[pos].hand]);
+    const nextWallTile = state.wall[0];
+    const displayTiles = nextWallTile ? [...cpuHand, nextWallTile] : cpuHand;
+
+    for (const tile of displayTiles) {
+      const img = document.createElement('img');
+      img.src = getTileImagePath(tile);
+      img.alt = getTileLabel(tile);
+      img.draggable = false;
+      img.title = `${getTileLabel(tile)} — この牌を捕てる`;
+      img.className = 'debug-tile debug-tile--wall' + (tile.uid === nextWallTile?.uid ? ' debug-tile--next' : '');
+      img.addEventListener('click', () => {
+        onUpdate(cpuDrawAndDiscardAt(state, tile.uid));
+      });
+      handRow.appendChild(img);
+    }
+    section.appendChild(handRow);
+  }
+
+  return section;
 }
 
 // ─── セクション1: 全プレイヤー手牌（表向き）+ シャンテン数 ─
@@ -145,10 +220,10 @@ function buildDebugHands(state: GameState): HTMLElement {
     const tilesEl = document.createElement('div');
     tilesEl.className = 'debug-hand-tiles';
 
-    const tiles = [...state.players[pos].hand];
-    if (pos === state.currentTurn && state.drawnTile) {
-      tiles.push(state.drawnTile);
-    }
+    // 手牌を理牌順にソートして表示
+    const hand = sortHand([...state.players[pos].hand]);
+    const tsumo = pos === state.currentTurn && state.drawnTile ? [state.drawnTile] : [];
+    const tiles = [...hand, ...tsumo];
 
     for (const tile of tiles) {
       const img = document.createElement('img');
@@ -172,16 +247,20 @@ function buildDebugHands(state: GameState): HTMLElement {
   return section;
 }
 
-// ─── セクション2: 残りツモ山 + 次ツモ牌選択 ─────────────
+// ─── セクション2: 残りツモ山 ───────────────────────────────────
 function buildDebugWall(state: GameState, onUpdate: UpdateFn): HTMLElement {
+  // 現在の手番プレイヤーからプレイヤー(自分)の次ツモまで何枚消費されるか計算
+  // playerTurn なら山[0]を自分の次ツモに設定する (drawnTileはすでに設定済みのため swap)
+  // cpuTurn なら CPU の次数分の後持に自分のツモが発生する
+
+  const playerDrawOffset = calcPlayerDrawOffset(state);
   const section = buildSection(
-    `残りツモ山 (${state.wall.length}枚) — 牌をクリックで次ツモに移動`,
+    `残りツモ山 (${state.wall.length}枚) — 牌をクリックで「自分の次ツモ」に指定 (現在の位置: wall[${playerDrawOffset}])`,
   );
 
   const wallGrid = document.createElement('div');
   wallGrid.className = 'debug-wall-grid';
 
-  // 表示は理牌順に並べるが、クリック時はオリジナルの wall 配列インデックスで操作する
   const sorted = sortHand([...state.wall]);
   sorted.forEach((tile) => {
     const origIdx = state.wall.findIndex(t => t.uid === tile.uid);
@@ -189,20 +268,58 @@ function buildDebugWall(state: GameState, onUpdate: UpdateFn): HTMLElement {
     img.src = getTileImagePath(tile);
     img.alt = getTileLabel(tile);
     img.draggable = false;
-    img.title = `${getTileLabel(tile)} — クリックで次ツモに設定`;
+    img.title = `${getTileLabel(tile)} — クリックで自分の次ツモに指定`;
+    // 現在自分の次ツモ位置をハイライト
     img.className =
-      'debug-tile debug-tile--wall' + (origIdx === 0 ? ' debug-tile--next' : '');
+      'debug-tile debug-tile--wall' + (origIdx === playerDrawOffset ? ' debug-tile--next' : '');
     img.addEventListener('click', () => {
-      const newWall = [...state.wall];
-      newWall.splice(origIdx, 1);
-      newWall.unshift(tile);
-      onUpdate({ ...state, wall: newWall });
+      onUpdate(setPlayerNextDraw(state, tile));
     });
     wallGrid.appendChild(img);
   });
 
+  // playerTurn且つ drawnTile ありの場合は置換対象の説明を追加
+  if (state.phase === 'playerTurn' && state.drawnTile) {
+    const note = document.createElement('div');
+    note.className = 'debug-subtitle';
+    note.textContent = `※ 自分はすでにツモ済み (${getTileLabel(state.drawnTile)})。クリックするとそのツモ牌と入れ替えます。`;
+    section.appendChild(note);
+  }
+
   section.appendChild(wallGrid);
   return section;
+}
+
+// 自分 ('player') の次ツモ位置 (wall[何番目]) を返す
+function calcPlayerDrawOffset(state: GameState): number {
+  if (state.phase !== 'cpuTurn') return 0;
+  let offset = 0;
+  let cur = TURN_ORDER.indexOf(state.currentTurn);
+  while (TURN_ORDER[cur % 4] !== 'player') {
+    offset++;
+    cur++;
+  }
+  return offset;
+}
+
+// 指定牌を自分の次ツモに設定する
+function setPlayerNextDraw(state: GameState, tile: Tile): GameState {
+  const idx = state.wall.findIndex(t => t.uid === tile.uid);
+  if (idx === -1) return state;
+
+  // playerTurn 且つ drawnTile あり → drawnTile と入れ替え
+  if (state.phase === 'playerTurn' && state.drawnTile) {
+    const newWall = [...state.wall];
+    newWall.splice(idx, 1, state.drawnTile); // 古い drawnTile を山の同位置に戻す
+    return { ...state, drawnTile: tile, wall: newWall };
+  }
+
+  // cpuTurn → 自分のツモ位置まで移動
+  const offset = calcPlayerDrawOffset(state);
+  const newWall = [...state.wall];
+  newWall.splice(idx, 1);
+  newWall.splice(offset, 0, tile);
+  return { ...state, wall: newWall };
 }
 
 // ─── セクション3: カスタム配牌 ───────────────────────────

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -269,7 +269,9 @@ function buildDebugWall(state: GameState, onUpdate: UpdateFn): HTMLElement {
   const wallGrid = document.createElement('div');
   wallGrid.className = 'debug-wall-grid';
 
-  state.wall.forEach((tile, origIdx) => {
+  const sorted = sortHand([...state.wall]);
+  sorted.forEach((tile) => {
+    const origIdx = state.wall.findIndex(t => t.uid === tile.uid);
     const img = document.createElement('img');
     img.src = getTileImagePath(tile);
     img.alt = getTileLabel(tile);

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -134,7 +134,7 @@ function buildDebugPanel(
   return panel;
 }
 
-// ─── CPU 操作モードセレクター + 手動捕作 UI ────────────────
+// ─── CPU 操作モードセレクター + 手動操作 UI ────────────────
 function buildDebugCpuMode(
   state: GameState,
   onUpdate: UpdateFn,
@@ -269,9 +269,7 @@ function buildDebugWall(state: GameState, onUpdate: UpdateFn): HTMLElement {
   const wallGrid = document.createElement('div');
   wallGrid.className = 'debug-wall-grid';
 
-  const sorted = sortHand([...state.wall]);
-  sorted.forEach((tile) => {
-    const origIdx = state.wall.findIndex(t => t.uid === tile.uid);
+  state.wall.forEach((tile, origIdx) => {
     const img = document.createElement('img');
     img.src = getTileImagePath(tile);
     img.alt = getTileLabel(tile);
@@ -312,6 +310,9 @@ function calcPlayerDrawOffset(state: GameState): number {
 
 // 指定牌を自分の次ツモに設定する
 function setPlayerNextDraw(state: GameState, tile: Tile): GameState {
+  // playerTurn / cpuTurn 以外のフェーズでは操作しない
+  if (state.phase !== 'playerTurn' && state.phase !== 'cpuTurn') return state;
+
   const idx = state.wall.findIndex(t => t.uid === tile.uid);
   if (idx === -1) return state;
 
@@ -420,6 +421,7 @@ function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTML
     ...state.wall,
     ...TURN_ORDER.flatMap(pos => state.players[pos].hand),
     ...(state.drawnTile ? [state.drawnTile] : []),
+    ...(state.doraTile ? [state.doraTile] : []),
   ];
 
   for (const preset of YAKU_PRESETS) {
@@ -480,6 +482,7 @@ function buildHandPicker(state: GameState, onDebugRestart: DebugRestartFn): HTML
     ...state.wall,
     ...TURN_ORDER.flatMap(pos => state.players[pos].hand),
     ...(state.drawnTile ? [state.drawnTile] : []),
+    ...(state.doraTile ? [state.doraTile] : []),
   ]);
 
   const pickerGrid = document.createElement('div');

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -161,7 +161,7 @@ function buildDebugCpuMode(
   }
   section.appendChild(modeRow);
 
-  // 手動操作モード且つ cpuTurn の時: 当該 CPU の捕作 UI を表示
+  // 手動操作モード且つ cpuTurn の時: 当該 CPU の操作 UI を表示
   if (cpuMode === 'manual' && state.phase === 'cpuTurn') {
     const pos = state.currentTurn;
     const posLabels: Record<Position, string> = {
@@ -171,7 +171,7 @@ function buildDebugCpuMode(
 
     const manualTitle = document.createElement('div');
     manualTitle.className = 'debug-subtitle';
-    manualTitle.textContent = `${cpuName}の捕作牌を選択 (13枚の手牌 + 次ツモ牌):`;
+    manualTitle.textContent = `${cpuName}の操作牌を選択 (13枚の手牌 + 次ツモ牌)`;
     section.appendChild(manualTitle);
 
     const handRow = document.createElement('div');
@@ -187,7 +187,7 @@ function buildDebugCpuMode(
       img.src = getTileImagePath(tile);
       img.alt = getTileLabel(tile);
       img.draggable = false;
-      img.title = `${getTileLabel(tile)} — この牌を捕てる`;
+      img.title = `${getTileLabel(tile)} — この牌を捨てる`;
       img.className = 'debug-tile debug-tile--wall' + (tile.uid === nextWallTile?.uid ? ' debug-tile--next' : '');
       img.addEventListener('click', () => {
         onUpdate(cpuDrawAndDiscardAt(state, tile.uid));

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -17,7 +17,7 @@ import { renderBoard } from './board';
 import { initGameStateWithShanten, initGameStateWithHand, cpuDrawAndDiscardAt } from '../game/state';
 
 // CPU 操作モード
-export type DebugCpuMode = 'auto-discard' | 'manual' | 'ai';
+export type DebugCpuMode = 'auto-discard' | 'manual';
 type SetCpuModeFn = (mode: DebugCpuMode) => void;
 
 // ─── 役プリセット定義 ─────────────────────────────────────
@@ -149,7 +149,6 @@ function buildDebugCpuMode(
   const modes: { mode: DebugCpuMode; label: string }[] = [
     { mode: 'auto-discard', label: '自動ツモ切り' },
     { mode: 'manual',       label: '手動操作' },
-    { mode: 'ai',           label: 'AI操作' },
   ];
 
   for (const { mode, label } of modes) {
@@ -318,7 +317,8 @@ function setPlayerNextDraw(state: GameState, tile: Tile): GameState {
   const offset = calcPlayerDrawOffset(state);
   const newWall = [...state.wall];
   newWall.splice(idx, 1);
-  newWall.splice(offset, 0, tile);
+  const insertIndex = idx < offset ? offset - 1 : offset;
+  newWall.splice(insertIndex, 0, tile);
   return { ...state, wall: newWall };
 }
 

--- a/packages/client/src/ui/board-debug.ts
+++ b/packages/client/src/ui/board-debug.ts
@@ -17,7 +17,7 @@ import { renderBoard } from './board';
 import { initGameStateWithShanten, initGameStateWithHand, cpuDrawAndDiscardAt } from '../game/state';
 
 // CPU 操作モード
-export type DebugCpuMode = 'auto-discard' | 'manual';
+export type DebugCpuMode = 'auto-discard' | 'manual' | 'ai';
 type SetCpuModeFn = (mode: DebugCpuMode) => void;
 
 // ─── 役プリセット定義 ─────────────────────────────────────
@@ -149,6 +149,7 @@ function buildDebugCpuMode(
   const modes: { mode: DebugCpuMode; label: string }[] = [
     { mode: 'auto-discard', label: '自動ツモ切り' },
     { mode: 'manual',       label: '手動操作' },
+    { mode: 'ai',           label: 'AI操作' },
   ];
 
   for (const { mode, label } of modes) {
@@ -159,6 +160,14 @@ function buildDebugCpuMode(
     modeRow.appendChild(btn);
   }
   section.appendChild(modeRow);
+
+  // AI操作モード時: 現時点では自動ツモ切りと同じ動作であることを明示
+  if (cpuMode === 'ai') {
+    const aiNote = document.createElement('div');
+    aiNote.className = 'debug-subtitle';
+    aiNote.textContent = '※ AI操作は現時点では自動ツモ切りと同じ動作です（将来的に改善予定）';
+    section.appendChild(aiNote);
+  }
 
   // 手動操作モード且つ cpuTurn の時: 当該 CPU の操作 UI を表示
   if (cpuMode === 'manual' && state.phase === 'cpuTurn') {


### PR DESCRIPTION
## 概要
issue #2 に基づき、開発者向けのデバッグ用画面・機能を追加する。

closes #2

## 実装予定の内容
- [x] ツモ山から引き込む牌の任意選択
- [x] 残りのツモ山の中身を常時表示
- [x] 初期手牌の自由設定（役・シャンテン数・ランダム指定）
- [x] 他NPCの手牌の常時表示

## 設計方針
既存の `renderBoard()` が使う共通部品（`buildScorePanel()`・`buildSelfArea()`・`buildOpponentArea()` 等）をそのまま再利用し、デバッグ専用の `buildDebugPanel()` を追加する形で実装する。これにより、将来の機能追加・バグ修正が本番・デバッグ両画面に自動反映される。

## 関連issue
- #2 開発者デバッグ用画面・機能の追加

*このPRはGitHub Copilotによって作成されました。*