### PR TITLE
feat: 現在の手番プレイヤーをハイライト表示 (issue #12)

### DIFF
--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -80,6 +80,21 @@ h1 {
   color: #f0c040;
 }
 
+/* 自分のスコアエントリー */
+.score-entry--self .score-name {
+  color: #f0c040;
+}
+
+/* 手番プレイヤーのスコアエントリーをハイライト */
+.score-entry--active .score-name {
+  color: #4ade80;
+  font-weight: bold;
+}
+
+.score-entry--active .score-value {
+  color: #4ade80;
+}
+
 .score-name {
   font-size: 11px;
   color: #aaa;
@@ -192,6 +207,12 @@ h1 {
   padding-top: 6px;
 }
 
+/* 手番プレイヤーのエリアをハイライト */
+.area--active {
+  background: rgba(74, 222, 128, 0.08);
+  box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.5);
+}
+
 /* ─── プレイヤーラベル ──────────────────────────────── */
 .player-label {
   font-size: 11px;
@@ -255,6 +276,22 @@ h1 {
   color: #ccc;
   text-align: center;
   min-height: 16px;
+}
+
+/* 手番中は大きく強調表示（緑の補色：ピンク） */
+.phase-msg--active {
+  font-size: 14px;
+  font-weight: bold;
+  color: #f472b6;
+  text-shadow: 0 0 8px rgba(244, 114, 182, 0.6);
+}
+
+/* 和了時 */
+.phase-msg--agari {
+  font-size: 14px;
+  font-weight: bold;
+  color: #f0c040;
+  text-shadow: 0 0 8px rgba(240, 192, 64, 0.6);
 }
 
 /* ─── 捨て牌ゾーン (共通) ───────────────────────────── */

--- a/packages/client/src/ui/board.ts
+++ b/packages/client/src/ui/board.ts
@@ -102,13 +102,17 @@ function buildScorePanel(state: GameState, myPosition: Position | null): HTMLEle
 
   for (const { pos, label } of displayPositions) {
     const entry = document.createElement('div');
-    entry.className = 'score-entry' + (pos === selfPos ? ' score-entry--parent' : '');
+    const isActive = pos === state.currentTurn &&
+      (state.phase === 'playerTurn' || state.phase === 'cpuTurn');
+    entry.className = 'score-entry'
+      + (pos === selfPos ? ' score-entry--self' : '')
+      + (isActive ? ' score-entry--active' : '');
 
     const nameEl = document.createElement('span');
     nameEl.className = 'score-name';
     const wind = getSelfWind(pos, match.round);
     const pName = state.playerNames?.[pos] ?? label;
-    nameEl.textContent = `${pName}(${wind}${pos === parent ? '・親' : ''})`;
+    nameEl.textContent = (isActive ? '▶ ' : '') + `${pName}(${wind}${pos === parent ? '・親' : ''})`;
     entry.appendChild(nameEl);
 
     const scoreEl = document.createElement('span');
@@ -126,7 +130,9 @@ function buildScorePanel(state: GameState, myPosition: Position | null): HTMLEle
 // ─── 対面/上家/下家エリア (手牌のみ) ─────────────────────
 function buildOpponentArea(state: GameState, actualPos: Position, visualPos: 'toimen' | 'kami' | 'simo'): HTMLElement {
   const area = document.createElement('div');
-  area.className = `area area--${visualPos}`;
+  const isActive = state.currentTurn === actualPos &&
+    (state.phase === 'playerTurn' || state.phase === 'cpuTurn');
+  area.className = `area area--${visualPos}` + (isActive ? ' area--active' : '');
 
   const labels: Record<string, string> = { toimen: '対面', kami: '上家', simo: '下家' };
   area.appendChild(buildLabel(labels[visualPos]));
@@ -202,15 +208,15 @@ function buildWallInfo(state: GameState): HTMLElement {
 
   const msg = document.createElement('div');
   msg.className = 'phase-msg';
-  if (state.phase === 'playerTurn') {
-    const labels: Record<string, string> = { player: '自分', simo: '下家', toimen: '対面', kami: '上家' };
-    msg.textContent = `${labels[state.currentTurn] ?? ''}の番`;
-  } else if (state.phase === 'cpuTurn') {
-    const labels: Record<string, string> = { simo: '下家', toimen: '対面', kami: '上家' };
-    msg.textContent = `${labels[state.currentTurn] ?? ''}の番`;
+  const posLabels: Record<string, string> = { player: '自分', simo: '下家', toimen: '対面', kami: '上家' };
+  if (state.phase === 'playerTurn' || state.phase === 'cpuTurn') {
+    const turnName = state.playerNames?.[state.currentTurn] ?? posLabels[state.currentTurn] ?? '';
+    msg.textContent = `${turnName} の番`;
+    msg.classList.add('phase-msg--active');
   } else if (state.phase === 'agari') {
-    const winnerLabels: Record<string, string> = { player: '自分', simo: '下家', toimen: '対面', kami: '上家' };
-    msg.textContent = `${winnerLabels[state.agariInfo!.winner]}の和了！`;
+    const winnerName = state.playerNames?.[state.agariInfo!.winner] ?? posLabels[state.agariInfo!.winner];
+    msg.textContent = `${winnerName} の和了！`;
+    msg.classList.add('phase-msg--agari');
   } else if (state.phase === 'ryukyoku') {
     msg.textContent = '流局';
   } else if (state.phase === 'waitingRon') {
@@ -329,13 +335,12 @@ function buildPlayerArea(
   myPosition: Position | null,
 ): HTMLElement {
   const area = document.createElement('div');
-  area.className = 'area area--player';
+  const selfPos: Position = myPosition ?? 'player';
+  const isMyTurn = state.phase === 'playerTurn' && state.currentTurn === selfPos;
+  area.className = 'area area--player' + (isMyTurn ? ' area--active' : '');
 
   // オンライン時は「自分の座席」の手牌を表示する
   // myPosition=null はオフライン (player 固定)
-  const selfPos: Position = myPosition ?? 'player';
-  // 自分の手番かどうか (オンライン時は currentTurn が自座席のみ操作可)
-  const isMyTurn = state.phase === 'playerTurn' && state.currentTurn === selfPos;
   const isOnline = myPosition !== null;
 
   area.appendChild(buildPlayerHand(state, selfPos, isMyTurn, isOnline, onUpdate));


### PR DESCRIPTION
## 概要

issue #12「現在のプレイ中プレイヤーをより分かりやすく表示する」の対応です。

## 変更内容

### `packages/client/src/ui/board.ts`

- **`buildScorePanel()`**
  - `score-entry--parent` → `score-entry--self` にクラス名を変更（自分自身のエントリー用）
  - 手番プレイヤーに `score-entry--active` クラスを付与
  - 手番プレイヤーの名前の前に `▶` マークを表示
- **`buildWallInfo()`**
  - `playerNames` を参照して手番プレイヤー名を表示（例: `CPU南 の番`）
  - 手番中は `phase-msg--active`（ピンク色・グロー）クラスを付与
  - 和了時は `phase-msg--agari`（金色・グロー）クラスを付与
- **`buildOpponentArea()`**
  - 手番中の対戦相手エリアに `area--active` クラスを付与
- **`buildPlayerArea()`**
  - 自分の手番時に `area--active` クラスを付与

### `packages/client/src/style.css`

- `.score-entry--self .score-name` — 自分のスコア名を金色に
- `.score-entry--active .score-name` / `.score-value` — 手番プレイヤーを緑色・太字にハイライト
- `.area--active` — 手番エリア全体に緑の枠線とグローを追加
- `.phase-msg--active` — 手番メッセージをピンク色（緑の補色）で強調
- `.phase-msg--agari` — 和了メッセージを金色で強調

Closes #12