### PR TITLE
fix: 捨て牌の視認性と表示順を修正 (issue #24)

### DIFF
--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -301,9 +301,8 @@ h1 {
   padding: 3px;
 }
 
-/* 自分・対面: 横並び 8枚で折り返し・幅は8枚ちょうど */
-.discard-zone--player,
-.discard-zone--toimen {
+/* 自分: 横並び 8枚で折り返し・左→右・新しい行は下（手前から中央方向） */
+.discard-zone--player {
   display: grid;
   grid-template-columns: repeat(8, 48px);
   gap: 2px;
@@ -313,16 +312,40 @@ h1 {
   min-height: 52px;
 }
 
-/* 上家・下家: 縦並び 8枚で折り返し・幅は列数で自動 */
-.discard-zone--kami,
-.discard-zone--simo {
+/* 対面: 右→左に並べ、新しい行は上（対面の手牌側）へ追加 */
+/* flex-direction:row-reverse で右→左、wrap-reverse で行を下から上方向に積み上げ */
+.discard-zone--toimen {
+  display: flex;
+  flex-direction: row-reverse;
+  flex-wrap: wrap-reverse;
+  align-content: flex-start;
+  gap: 2px;
+  width: calc(8 * 48px + 7 * 2px);
+  min-height: 52px;
+}
+
+/* 上家: 縦並び 8枚で折り返し。direction:rtl で新しい列を左方向に追加 */
+/* JS逆順なし・既存牌はシフトしない */
+.discard-zone--kami {
   display: grid;
   grid-template-rows: repeat(8, 48px);
   grid-auto-flow: column;
+  direction: rtl;
   gap: 2px;
   min-width: 52px;
-  /* 高さは8×48+7×2=398px に収める */
   max-height: calc(8 * 48px + 7 * 2px);
+}
+
+/* 下家: 下から上へ積み上げ（自分視点で左→右と同じ並び順） */
+.discard-zone--simo {
+  display: flex;
+  flex-direction: column-reverse;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 52px;
+  /* 高さを固定してflex折り返しのトリガーにする */
+  height: calc(8 * 48px + 7 * 2px);
 }
 
 /* ─── 捨て牌画像 ────────────────────────────────────── */
@@ -333,6 +356,14 @@ h1 {
   width: 48px;
   height: 48px;
   object-fit: contain;
+}
+
+/* 直近（最後）に捨てた牌を強調表示 */
+.discard-tile--latest {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: -2px;
+  border-radius: 2px;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.7));
 }
 
 /* ─── 手牌コンテナ ──────────────────────────────────── */

--- a/packages/client/src/ui/board.ts
+++ b/packages/client/src/ui/board.ts
@@ -152,21 +152,35 @@ function buildCenterTable(
   const center = document.createElement('div');
   center.className = 'center-table';
 
+  // ゲーム全体で「直前に捨てられた1枚」を特定する。
+  // waitingRon は捨てた沖が明で、それ以外は現在手番の1つ前のプレイヤーの最後の捨て牌。
+  let latestDiscardUid: number | null = null;
+  if (state.phase === 'waitingRon' && state.waitingRon) {
+    latestDiscardUid = state.waitingRon.tile.uid;
+  } else if (state.phase === 'playerTurn' || state.phase === 'cpuTurn') {
+    const prevIdx = (TURN_ORDER.indexOf(state.currentTurn) - 1 + 4) % 4;
+    const prevPos = TURN_ORDER[prevIdx];
+    const prevDiscards = state.players[prevPos].discards;
+    if (prevDiscards.length > 0) {
+      latestDiscardUid = prevDiscards[prevDiscards.length - 1].uid;
+    }
+  }
+
   // 上段: 対面の河
-  center.appendChild(buildDiscardZone(state, toimenPos, 'toimen'));
+  center.appendChild(buildDiscardZone(state, toimenPos, 'toimen', latestDiscardUid));
 
   // 中段: 上家の河 | 山情報 | 下家の河
   const centerRow = document.createElement('div');
   centerRow.className = 'center-row';
 
-  centerRow.appendChild(buildDiscardZone(state, kamiPos, 'kami'));
+  centerRow.appendChild(buildDiscardZone(state, kamiPos, 'kami', latestDiscardUid));
   centerRow.appendChild(buildWallInfo(state));
-  centerRow.appendChild(buildDiscardZone(state, simoPos, 'simo'));
+  centerRow.appendChild(buildDiscardZone(state, simoPos, 'simo', latestDiscardUid));
 
   center.appendChild(centerRow);
 
   // 下段: 自分の河
-  center.appendChild(buildDiscardZone(state, selfPos, 'player'));
+  center.appendChild(buildDiscardZone(state, selfPos, 'player', latestDiscardUid));
 
   return center;
 }
@@ -229,16 +243,26 @@ function buildWallInfo(state: GameState): HTMLElement {
 
 // ─── 捨て牌ゾーン (4方向共通、_furo.gif を使用) ─────────
 // actualPos: データアクセス用実座席, visualPos: CSS/画像パス用視覚位置
-function buildDiscardZone(state: GameState, actualPos: Position, visualPos: Position): HTMLElement {
+// latestDiscardUid: ゲーム全体で最後に捨てられた牌の uid (なければ null)
+function buildDiscardZone(state: GameState, actualPos: Position, visualPos: Position, latestDiscardUid: number | null): HTMLElement {
   const zone = document.createElement('div');
   zone.className = `discard-zone discard-zone--${visualPos}`;
 
-  state.players[actualPos].discards.forEach((tile) => {
+  const discards = state.players[actualPos].discards;
+
+  // JS 側では全方向ともオリジナル順（古い順）のまま使用する。
+  // 対面: CSS flex-direction:row-reverse + wrap-reverse で右→左・上方向に行追加
+  // 上家: CSS direction:rtl + grid-auto-flow:column で右列→左列方向に列追加
+  // 下家: CSS flex-direction:column-reverse で下→上方向に積み上げ
+  const tiles = discards;
+
+  tiles.forEach((tile) => {
     const img = document.createElement('img');
     img.src = getDiscardImagePath(tile, visualPos);
     img.alt = getTileLabel(tile);
     img.draggable = false;
-    img.className = 'discard-tile';
+    img.className = 'discard-tile'
+      + (latestDiscardUid !== null && tile.uid === latestDiscardUid ? ' discard-tile--latest' : '');
     zone.appendChild(img);
   });
 


### PR DESCRIPTION
## 概要

issue #24「捨て牌の視認性が低い・表示順が直感に反する」の対応です。

## 変更内容

### 1. 最新捨て牌のハイライト（`packages/client/src/ui/board.ts`）

ゲーム全体で「最後に捨てた1枚のみ」を `discard-tile--latest` クラスでハイライト。

| フェーズ | 特定方法 |
|---|---|
| `waitingRon` | `state.waitingRon.tile.uid` を直接参照 |
| `playerTurn` / `cpuTurn` | `currentTurn` の1つ前のプレイヤーの discards 末尾 |
| それ以外 | ハイライトなし |

### 2. 捨て牌の表示順をどのプレイヤー視点でも左→右に統一（`style.css`）

| プレイヤー | 修正前 | 修正後 |
|---|---|---|
| **自分 (player)** | grid 左→右・新行は下 ✓ | 変更なし |
| **対面 (toimen)** | `direction:rtl` + grid → 新行が下（自分側）に追加されていた | `flex row-reverse + wrap-reverse` → 新行が上（対面の手牌側）に追加 ✅ |
| **上家 (kami)** | JS逆順 + grid → 9枚目以降で既存牌がシフトしていた | JS逆順廃止 + CSS `direction:rtl` → 既存牌は固定、新列が左（上家の下方向）に追加 ✅ |
| **下家 (simo)** | `flex column-reverse` で下→上積み上げ ✓ | 変更なし |

### 3. `.discard-tile--latest` スタイル追加（`style.css`）

白アウトライン＋白グロー (`drop-shadow`) で最新捨て牌を視覚的に強調。

Closes #24