### PR TITLE
fix: 捨て牌ゾーンのレイアウトシフト修正と6牌折り返しへの変更 (issue #7, #11)

### DIFF
--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -309,7 +309,9 @@ h1 {
   align-content: start;
   /* 6枚×48px + 5gap×2px = 298px、padding含め固定幅 */
   width: calc(6 * 48px + 5 * 2px);
-  min-height: 52px;
+  /* 最大行数を3行分で固定—捨て牌が増えてもレイアウトシフトしない */
+  height: calc(3 * 48px + 2 * 2px);
+  overflow: hidden;
 }
 
 /* 対面: 右→左に並べ、新しい行は上（対面の手牌側）へ追加 */
@@ -321,7 +323,9 @@ h1 {
   align-content: flex-start;
   gap: 2px;
   width: calc(6 * 48px + 5 * 2px);
-  min-height: 52px;
+  /* 最大行数を3行分で固定 */
+  height: calc(3 * 48px + 2 * 2px);
+  overflow: hidden;
 }
 
 /* 上家: 縦並び 6枚で折り返し。direction:rtl で新しい列を左方向に追加 */
@@ -332,8 +336,10 @@ h1 {
   grid-auto-flow: column;
   direction: rtl;
   gap: 2px;
-  min-width: 52px;
-  max-height: calc(6 * 48px + 5 * 2px);
+  /* 最大列数を3列分で固定 */
+  width: calc(3 * 48px + 2 * 2px);
+  height: calc(6 * 48px + 5 * 2px);
+  overflow: hidden;
 }
 
 /* 下家: 下から上へ積み上げ（自分視点で左→右と同じ並び順） */
@@ -343,9 +349,10 @@ h1 {
   flex-wrap: wrap;
   align-items: flex-start;
   gap: 2px;
-  min-width: 52px;
-  /* 高さを固定してflex折り返しのトリガーにする */
+  /* 最大列数を3列分で固定 */
+  width: calc(3 * 48px + 2 * 2px);
   height: calc(6 * 48px + 5 * 2px);
+  overflow: hidden;
 }
 
 /* ─── 捨て牌画像 ────────────────────────────────────── */

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -301,14 +301,14 @@ h1 {
   padding: 3px;
 }
 
-/* 自分: 横並び 8枚で折り返し・左→右・新しい行は下（手前から中央方向） */
+/* 自分: 横並び 6枚で折り返し・左→右・新しい行は下（手前から中央方向） */
 .discard-zone--player {
   display: grid;
-  grid-template-columns: repeat(8, 48px);
+  grid-template-columns: repeat(6, 48px);
   gap: 2px;
   align-content: start;
-  /* 8枚×48px + 7gap×2px = 398px、padding含め固定幅 */
-  width: calc(8 * 48px + 7 * 2px);
+  /* 6枚×48px + 5gap×2px = 298px、padding含め固定幅 */
+  width: calc(6 * 48px + 5 * 2px);
   min-height: 52px;
 }
 
@@ -320,20 +320,20 @@ h1 {
   flex-wrap: wrap-reverse;
   align-content: flex-start;
   gap: 2px;
-  width: calc(8 * 48px + 7 * 2px);
+  width: calc(6 * 48px + 5 * 2px);
   min-height: 52px;
 }
 
-/* 上家: 縦並び 8枚で折り返し。direction:rtl で新しい列を左方向に追加 */
+/* 上家: 縦並び 6枚で折り返し。direction:rtl で新しい列を左方向に追加 */
 /* JS逆順なし・既存牌はシフトしない */
 .discard-zone--kami {
   display: grid;
-  grid-template-rows: repeat(8, 48px);
+  grid-template-rows: repeat(6, 48px);
   grid-auto-flow: column;
   direction: rtl;
   gap: 2px;
   min-width: 52px;
-  max-height: calc(8 * 48px + 7 * 2px);
+  max-height: calc(6 * 48px + 5 * 2px);
 }
 
 /* 下家: 下から上へ積み上げ（自分視点で左→右と同じ並び順） */
@@ -345,7 +345,7 @@ h1 {
   gap: 2px;
   min-width: 52px;
   /* 高さを固定してflex折り返しのトリガーにする */
-  height: calc(8 * 48px + 7 * 2px);
+  height: calc(6 * 48px + 5 * 2px);
 }
 
 /* ─── 捨て牌画像 ────────────────────────────────────── */

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -304,14 +304,14 @@ h1 {
 /* 自分: 横並び 6枚で折り返し・左→右・新しい行は下（手前から中央方向） */
 .discard-zone--player {
   display: grid;
-  grid-template-columns: repeat(6, 48px);
-  gap: 2px;
+  grid-template-columns: repeat(6, 37px);
+  gap: 4px;
   align-content: start;
   padding: 0;
   /* .discard-zone の padding:3px を上書きして6枚ちょうど収まるようにする */
-  width: calc(6 * 48px + 5 * 2px);
+  width: calc(6 * 37px + 5 * 4px);
   /* 4行分で固定（最大24枚）—牌が増えてもレイアウトシフトしない */
-  height: calc(4 * 48px + 3 * 2px);
+  height: calc(4 * 55px + 3 * 4px);
   overflow: hidden;
 }
 
@@ -322,11 +322,11 @@ h1 {
   flex-direction: row-reverse;
   flex-wrap: wrap-reverse;
   align-content: flex-start;
-  gap: 2px;
+  gap: 4px;
   padding: 0;
-  width: calc(6 * 48px + 5 * 2px);
+  width: calc(6 * 37px + 5 * 4px);
   /* 4行分で固定 */
-  height: calc(4 * 48px + 3 * 2px);
+  height: calc(4 * 55px + 3 * 4px);
   overflow: hidden;
 }
 
@@ -334,16 +334,16 @@ h1 {
 /* JS逆順なし・既存牌はシフトしない */
 .discard-zone--kami {
   display: grid;
-  grid-template-rows: repeat(6, 48px);
+  grid-template-rows: repeat(6, 53px);
   grid-auto-flow: column;
   grid-auto-columns: 48px;
   /* 列幅を固定して間隔を均一に */
   direction: rtl;
-  gap: 2px;
+  gap: 4px;
   padding: 0;
   /* 4列分で固定（最大24枚） */
-  width: calc(4 * 48px + 3 * 2px);
-  height: calc(6 * 48px + 5 * 2px);
+  width: calc(4 * 48px + 3 * 4px);
+  height: calc(6 * 53px + 5 * 4px);
   overflow: hidden;
 }
 
@@ -355,30 +355,41 @@ h1 {
   align-items: flex-start;
   /* flex-start で列を左端に詰める→列数が変わっても列間隔が均一 */
   align-content: flex-start;
-  gap: 2px;
+  gap: 4px;
   padding: 0;
   /* 4列分で固定（最大24枚） */
-  width: calc(4 * 48px + 3 * 2px);
-  height: calc(6 * 48px + 5 * 2px);
+  width: calc(4 * 48px + 3 * 4px);
+  height: calc(6 * 53px + 5 * 4px);
   overflow: hidden;
 }
 
 /* ─── 捨て牌画像 ────────────────────────────────────── */
-/* 全方向で 48×48px の正方形スロットに object-fit: contain で収める。
-   縦向き画像 (33×59) も横向き画像 (59×33) も同一スケール (0.81x) で表示される */
+/* 「牌の高さ」を48pxに統一（方法3: 画像の自然比率から正規化）
+   player/toimen(33×59): 牌の高さ=59 → 37×55px（ユーザー指定サイズ）
+   kami/simo(44×49):     牌の高さ=44 → 48/44スケール → 48×53px */
 .discard-tile {
   display: block;
+  object-fit: fill;
+}
+
+.discard-zone--player .discard-tile,
+.discard-zone--toimen .discard-tile {
+  width: 36px;
+  height: 55px;
+}
+
+.discard-zone--kami .discard-tile,
+.discard-zone--simo .discard-tile {
   width: 48px;
-  height: 48px;
-  object-fit: contain;
+  height: 53px;
 }
 
 /* 直近（最後）に捨てた牌を強調表示 */
 .discard-tile--latest {
-  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline: 3px solid rgba(255, 210, 0, 0.95);
   outline-offset: -2px;
   border-radius: 2px;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.7));
+  filter: drop-shadow(0 0 5px rgba(255, 200, 0, 0.85));
 }
 
 /* ─── 手牌コンテナ ──────────────────────────────────── */

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -307,10 +307,11 @@ h1 {
   grid-template-columns: repeat(6, 48px);
   gap: 2px;
   align-content: start;
-  /* 6枚×48px + 5gap×2px = 298px、padding含め固定幅 */
+  padding: 0;
+  /* .discard-zone の padding:3px を上書きして6枚ちょうど収まるようにする */
   width: calc(6 * 48px + 5 * 2px);
-  /* 最大行数を3行分で固定—捨て牌が増えてもレイアウトシフトしない */
-  height: calc(3 * 48px + 2 * 2px);
+  /* 4行分で固定（最大24枚）—牌が増えてもレイアウトシフトしない */
+  height: calc(4 * 48px + 3 * 2px);
   overflow: hidden;
 }
 
@@ -322,9 +323,10 @@ h1 {
   flex-wrap: wrap-reverse;
   align-content: flex-start;
   gap: 2px;
+  padding: 0;
   width: calc(6 * 48px + 5 * 2px);
-  /* 最大行数を3行分で固定 */
-  height: calc(3 * 48px + 2 * 2px);
+  /* 4行分で固定 */
+  height: calc(4 * 48px + 3 * 2px);
   overflow: hidden;
 }
 
@@ -334,10 +336,13 @@ h1 {
   display: grid;
   grid-template-rows: repeat(6, 48px);
   grid-auto-flow: column;
+  grid-auto-columns: 48px;
+  /* 列幅を固定して間隔を均一に */
   direction: rtl;
   gap: 2px;
-  /* 最大列数を3列分で固定 */
-  width: calc(3 * 48px + 2 * 2px);
+  padding: 0;
+  /* 4列分で固定（最大24枚） */
+  width: calc(4 * 48px + 3 * 2px);
   height: calc(6 * 48px + 5 * 2px);
   overflow: hidden;
 }
@@ -348,9 +353,12 @@ h1 {
   flex-direction: column-reverse;
   flex-wrap: wrap;
   align-items: flex-start;
+  /* flex-start で列を左端に詰める→列数が変わっても列間隔が均一 */
+  align-content: flex-start;
   gap: 2px;
-  /* 最大列数を3列分で固定 */
-  width: calc(3 * 48px + 2 * 2px);
+  padding: 0;
+  /* 4列分で固定（最大24枚） */
+  width: calc(4 * 48px + 3 * 2px);
   height: calc(6 * 48px + 5 * 2px);
   overflow: hidden;
 }


### PR DESCRIPTION
## 概要

issue #7 と issue #11 を同時に対応します。

- **#7**: 捨て牌が増えるとレイアウトシフトが発生する
- **#11**: 捨て牌の折り返しを8牌から6牌に変更する

## 変更予定内容

### issue #11 — 折り返しを8牌→6牌に変更（`style.css`）

| セレクタ | 変更内容 |
|---|---|
| `.discard-zone--player` / `.discard-zone--toimen` | `grid-template-columns: repeat(8, 48px)` → `repeat(6, 48px)` |
| `.discard-zone--player` / `.discard-zone--toimen` | `width: calc(8 * 48px + 7 * 2px)` → `calc(6 * 48px + 5 * 2px)` |
| `.discard-zone--kami` | `grid-template-rows: repeat(8, 48px)` → `repeat(6, 48px)` |
| `.discard-zone--simo` | flex の折り返し高さを6牌分に変更 |

### issue #7 — ゾーンサイズを対局開始時から固定（`style.css`）

- `--player` / `--toimen`: `min-height` を削除し `height` を3行分 (`calc(3 * 48px + 2 * 2px)`) で固定
- `--kami`: `max-height` を削除し `height` を3列分で固定
- `--simo`: `height` を3列分で固定

Closes #7
Closes #11