### PR TITLE
fix: 和了時にプレイヤー名を表示するよう修正 (issue #16)

### DIFF
--- a/packages/client/src/ui/board.ts
+++ b/packages/client/src/ui/board.ts
@@ -489,8 +489,7 @@ function buildPlayerArea(
     const info = state.agariInfo!;
     const overlay = document.createElement('div');
     overlay.className = 'agari-overlay';
-    const winnerLabels: Record<string, string> = { player: '自分', simo: '下家', toimen: '対面', kami: '上家' };
-    const winnerName = winnerLabels[info.winner];
+    const winnerName = state.playerNames?.[info.winner] ?? info.winner;
     const agariType = info.isTsumo ? 'ツモ' : 'ロン';
 
     const title = document.createElement('span');


### PR DESCRIPTION
## 概要

issue #16 の対応として、和了オーバーレイのプレイヤー表示を固定ラベルからプレイヤー名に変更しました。

## 変更内容

### `packages/client/src/ui/board.ts`
- `buildPlayerArea()` 内の和了オーバーレイで `winnerLabels`（「自分」「下家」「対面」「上家」）を廃止
- `state.playerNames?.[info.winner]` を参照するよう変更

## 動作

| モード | 表示 |
|--------|------|
| オフライン | 「あなた」「CPU南」「CPU西」「CPU北」 |
| オンライン | ロビーで入力したプレイヤー名 |

なお `buildWallInfo()` の「〇〇の和了！」テキストは既に `state.playerNames` を参照していたため変更不要でした。

Closes #16