### PR TITLE
feat: リーチ中プレイヤーの視覚的表示 (issue #13)

### DIFF
--- a/packages/client/src/game/state.ts
+++ b/packages/client/src/game/state.ts
@@ -37,6 +37,7 @@ export function initGameState(match?: MatchState): GameState {
 
   // リーチ状態: 全員false
   const riichi: GameState['riichi'] = { player: false, simo: false, toimen: false, kami: false };
+  const riichiTileUid: GameState['riichiTileUid'] = { player: null, simo: null, toimen: null, kami: null };
 
   return {
     wall,
@@ -48,6 +49,7 @@ export function initGameState(match?: MatchState): GameState {
     agariInfo: null,
     doraTile,
     riichi,
+    riichiTileUid,
     match: currentMatch,
     playerNames: { player: 'あなた', simo: 'CPU南', toimen: 'CPU西', kami: 'CPU北' },
     waitingRon: null,
@@ -127,6 +129,7 @@ export function declareRiichi(state: GameState): GameState {
     phase: 'cpuTurn',
     currentTurn: next,
     riichi: { ...state.riichi, player: true },
+    riichiTileUid: { ...state.riichiTileUid, player: discarded.uid },
   };
 
   // 次がプレイヤーならツモ牌を先に引いておく
@@ -446,6 +449,7 @@ export function initGameStateWithHand(hand: Tile[], match?: MatchState): GameSta
   const drawnTile = wall.shift()!;
   const doraTile = wall.pop()!;
   const riichi: GameState['riichi'] = { player: false, simo: false, toimen: false, kami: false };
+  const riichiTileUid: GameState['riichiTileUid'] = { player: null, simo: null, toimen: null, kami: null };
 
   return {
     wall,
@@ -457,6 +461,7 @@ export function initGameStateWithHand(hand: Tile[], match?: MatchState): GameSta
     agariInfo: null,
     doraTile,
     riichi,
+    riichiTileUid,
     match: currentMatch,
     playerNames: { player: 'あなた', simo: 'CPU南', toimen: 'CPU西', kami: 'CPU北' },
     waitingRon: null,

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -499,6 +499,14 @@ h1 {
   filter: drop-shadow(0 0 5px rgba(255, 200, 0, 0.85));
 }
 
+/* リーチ宣言牌: 橙色ハイライト */
+.discard-tile--riichi {
+  outline: 3px solid rgba(255, 140, 0, 0.95);
+  outline-offset: -2px;
+  border-radius: 2px;
+  filter: drop-shadow(0 0 5px rgba(255, 120, 0, 0.85));
+}
+
 /* ─── 手牌コンテナ ──────────────────────────────────── */
 .hand {
   display: flex;
@@ -688,6 +696,24 @@ h1 {
   border-radius: 4px;
   letter-spacing: 0.1em;
   animation: tenpai-pulse 1s ease-in-out infinite;
+}
+
+/* 他プレイヤーエリア内のリーチラベル: 小さめ */
+.riichi-label--opponent {
+  font-size: 11px;
+  padding: 1px 6px;
+}
+
+/* スコアパネルの R バッジ */
+.riichi-badge {
+  display: inline-block;
+  padding: 0px 4px;
+  background: #8e44ad;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  border-radius: 3px;
+  letter-spacing: 0;
 }
 
 @keyframes tenpai-pulse {

--- a/packages/client/src/ui/board.ts
+++ b/packages/client/src/ui/board.ts
@@ -151,6 +151,12 @@ function buildScorePanel(state: GameState, myPosition: Position | null): HTMLEle
     const scoreEl = document.createElement('span');
     scoreEl.className = 'score-value';
     scoreEl.textContent = match.scores[pos].toLocaleString();
+    if (state.riichi[pos]) {
+      const rBadge = document.createElement('span');
+      rBadge.className = 'riichi-badge';
+      rBadge.textContent = 'R';
+      entry.appendChild(rBadge);
+    }
     entry.appendChild(scoreEl);
 
     scoreList.appendChild(entry);
@@ -169,6 +175,12 @@ function buildOpponentArea(state: GameState, actualPos: Position, visualPos: 'to
 
   const labels: Record<string, string> = { toimen: '対面', kami: '上家', simo: '下家' };
   area.appendChild(buildLabel(labels[visualPos]));
+  if (state.riichi[actualPos]) {
+    const riichiLabel = document.createElement('span');
+    riichiLabel.className = 'riichi-label riichi-label--opponent';
+    riichiLabel.textContent = '立直';
+    area.appendChild(riichiLabel);
+  }
   area.appendChild(buildCpuHand(state, actualPos, visualPos));
 
   return area;
@@ -315,8 +327,10 @@ function buildDiscardZone(state: GameState, actualPos: Position, visualPos: Posi
     img.src = getDiscardImagePath(tile, visualPos);
     img.alt = getTileLabel(tile);
     img.draggable = false;
+    const isRiichiTile = state.riichiTileUid[actualPos] === tile.uid;
     img.className = 'discard-tile'
-      + (latestDiscardUid !== null && tile.uid === latestDiscardUid ? ' discard-tile--latest' : '');
+      + (latestDiscardUid !== null && tile.uid === latestDiscardUid ? ' discard-tile--latest' : '')
+      + (isRiichiTile ? ' discard-tile--riichi' : '');
     zone.appendChild(img);
   });
 

--- a/packages/server/src/actions.ts
+++ b/packages/server/src/actions.ts
@@ -59,6 +59,7 @@ export function initGameState(match?: MatchState, playerNames?: Map<Position, st
   const drawnTile = wall.shift()!;
   const doraTile = wall.pop()!;
   const riichi: GameState['riichi'] = { player: false, simo: false, toimen: false, kami: false };
+  const riichiTileUid: GameState['riichiTileUid'] = { player: null, simo: null, toimen: null, kami: null };
   const names: GameState['playerNames'] = {
     player: playerNames?.get('player') ?? 'Player',
     simo:   playerNames?.get('simo')   ?? 'Simo',
@@ -76,6 +77,7 @@ export function initGameState(match?: MatchState, playerNames?: Map<Position, st
     agariInfo: null,
     doraTile,
     riichi,
+    riichiTileUid,
     match: currentMatch,
     playerNames: names,
     waitingRon: null,
@@ -201,6 +203,7 @@ export function declareRiichiAt(state: GameState, pos: Position): GameState {
     drawnTile: null,
     selectedIndex: null,
     riichi: { ...state.riichi, [pos]: true },
+    riichiTileUid: { ...state.riichiTileUid, [pos]: discarded.uid },
     currentTurn: next,
   }, next);
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -97,6 +97,7 @@ export interface GameState {
   agariInfo: AgariInfo | null;          // 和了情報 (phase === 'agari' 時のみ非null)
   doraTile: Tile;                       // ドラ表示牌 (公開)
   riichi: Record<Position, boolean>;   // リーチ状態
+  riichiTileUid: Record<Position, number | null>; // リーチ宣言牌のuid (null=未リーチ)
   match: MatchState;                    // 対局状態
   playerNames: Record<Position, string>; // プレイヤー名
   waitingRon: WaitingRonState | null;  // ロン確認待ち (phase === 'waitingRon' 時のみ非null)


### PR DESCRIPTION
Closes #13

## 変更内容

### 他プレイヤーエリアへのリーチ表示
- `buildOpponentArea()` で `state.riichi[actualPos]` が真のとき「立直」ラベル（`riichi-label--opponent`）を表示

### スコアパネルへのリーチ状態表示
- リーチ中プレイヤーのスコアエントリーに「R」バッジ（`riichi-badge`）を追加

### リーチ宣言牌のハイライト
- `riichiTileUid` を `GameState` に追加し、リーチ宣言時に宣言牌のuidを記録
- 捨て牌ゾーンでリーチ宣言牌に `discard-tile--riichi` クラスを付与し、橙色の常時ハイライトを表示

### 変更ファイル
- `packages/shared/src/types.ts` — `GameState` に `riichiTileUid` フィールド追加
- `packages/server/src/actions.ts` — 初期化・`declareRiichiAt()` で宣言牌uid記録
- `packages/client/src/game/state.ts` — オフライン用初期化・`declareRiichi()` で宣言牌uid記録
- `packages/client/src/ui/board.ts` — 他プレイヤーリーチラベル・Rバッジ・リーチ牌クラス付与
- `packages/client/src/style.css` — `.riichi-label--opponent`、`.riichi-badge`、`.discard-tile--riichi` 追加