### PR TITLE
feat: ダブルクリック/ダブルタップで即捨て牌 (issue #9)

### DIFF
--- a/packages/client/src/ui/board.ts
+++ b/packages/client/src/ui/board.ts
@@ -387,6 +387,15 @@ function buildPlayerHand(
             }
           }
         : undefined,
+      onDblClick: isMyTurn && !isRiichi
+        ? () => {
+            if (isOnline) {
+              sendAction({ type: 'discard', index: i });
+            } else {
+              onUpdate(discardTile(state, i));
+            }
+          }
+        : undefined,
     }));
   });
 
@@ -408,6 +417,13 @@ function buildPlayerHand(
           onUpdate({ ...state, selectedIndex: selected });
         } else {
           onUpdate(selectTile(state, -1));
+        }
+      },
+      onDblClick: () => {
+        if (isOnline) {
+          sendAction({ type: 'discard', index: -1 });
+        } else {
+          onUpdate(discardTile(state, -1));
         }
       },
     }));
@@ -682,7 +698,7 @@ function buildFinishedOverlay(state: GameState, onRestart: RestartFn): HTMLEleme
 // ─── 汎用: 手牌画像要素の生成 ────────────────────────
 function buildTileImg(
   tile: Tile,
-  opts: { selected?: boolean; className?: string; onClick?: () => void } = {},
+  opts: { selected?: boolean; className?: string; onClick?: () => void; onDblClick?: () => void } = {},
 ): HTMLImageElement {
   const img = document.createElement('img');
   img.src = getTileImagePath(tile);
@@ -698,6 +714,28 @@ function buildTileImg(
     img.style.cursor = 'pointer';
     img.addEventListener('click', opts.onClick);
   }
+
+  if (opts.onDblClick) {
+    img.style.cursor = 'pointer';
+    // PC: dblclick
+    img.addEventListener('dblclick', (e) => {
+      e.preventDefault();
+      opts.onDblClick!();
+    });
+    // スマートフォン: 300ms 以内の 2 回 touchend
+    let lastTouchTime = 0;
+    img.addEventListener('touchend', (e) => {
+      const now = Date.now();
+      if (now - lastTouchTime < 300) {
+        e.preventDefault();
+        opts.onDblClick!();
+        lastTouchTime = 0;
+      } else {
+        lastTouchTime = now;
+      }
+    });
+  }
+
   return img;
 }
 


### PR DESCRIPTION
Closes #9

## 変更内容

### `packages/client/src/ui/board.ts`

**`buildTileImg()`**
- `opts` に `onDblClick?: () => void` を追加
- PC向け: `dblclick` イベントで即捨て処理を呼び出し
- スマートフォン向け: `touchend` イベントで 300ms 以内の 2 回タップを検出して即捨て処理を呼び出し

**`buildPlayerHand()`**
- 手牌の各牌に `onDblClick` を追加（自分のターン中かつ非リーチ時のみ有効）
  - オフライン: `discardTile(state, i)` を直接呼び出し
  - オンライン: `sendAction({ type: 'discard', index: i })` を送信
- ツモ牌にも同様の `onDblClick` を追加（リーチ中のツモ切りにも対応）