### PR TITLE
feat: アガり手の公開表示とモーダル形式のオーバーレイ実装 (issue #15)

### DIFF
--- a/packages/client/src/game/state.ts
+++ b/packages/client/src/game/state.ts
@@ -98,6 +98,7 @@ export function declareTsumo(state: GameState): GameState {
       fu: scoreResult.fu,
       score: scoreResult.score,
       scoreDetail: scoreResult.scoreDetail,
+      hand,
     },
   };
 }
@@ -219,6 +220,7 @@ export function cpuDrawAndDiscard(state: GameState): GameState {
         fu: scoreResult.fu,
         score: scoreResult.score,
         scoreDetail: scoreResult.scoreDetail,
+        hand: cpuFullHand,
       },
     };
   }
@@ -319,6 +321,7 @@ export function declareRon(state: GameState): GameState {
       fu: scoreResult.fu,
       score: scoreResult.score,
       scoreDetail: scoreResult.scoreDetail,
+      hand,
     },
   };
 }
@@ -376,6 +379,7 @@ export function cpuDrawAndDiscardAt(state: GameState, discardUid: number): GameS
         fu: scoreResult.fu,
         score: scoreResult.score,
         scoreDetail: scoreResult.scoreDetail,
+        hand: cpuFullHand,
       },
     };
   }

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -729,17 +729,33 @@ h1 {
 }
 
 /* ─── 和了オーバーレイ ──────────────────────────────── */
+/* ─── 和了モーダル: バックドロップ ──────────────────── */
+.agari-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(80, 80, 80, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  /* バックドロップ自体のクリックを吸収してモーダル外を操作不可にする */
+  pointer-events: all;
+}
+
 .agari-overlay {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  margin-top: 12px;
-  padding: 14px 32px;
+  padding: 24px 40px;
   background: linear-gradient(135deg, rgba(180, 140, 20, 0.95), rgba(120, 80, 10, 0.95));
   border: 2px solid #f0c040;
   border-radius: 10px;
   box-shadow: 0 0 20px rgba(240, 192, 64, 0.6);
+  /* モーダルコンテンツはスクロール対応 */
+  max-height: 90vh;
+  overflow-y: auto;
+  pointer-events: all;
 }
 
 .agari-title {
@@ -754,6 +770,28 @@ h1 {
   font-size: 14px;
   color: #ffe599;
   letter-spacing: 0.1em;
+}
+
+/* ─── 和了手牌 ───────────────────────────────────────── */
+.agari-hand {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 3px;
+  margin: 4px 0;
+}
+
+.agari-hand__tile {
+  width: 30px;
+  height: auto;
+  display: block;
+  border-radius: 2px;
+}
+
+.agari-hand__tile--winning {
+  outline: 3px solid #ff6b00;
+  outline-offset: -2px;
+  filter: drop-shadow(0 0 6px rgba(255, 107, 0, 0.9));
 }
 
 /* ─── 和了画面: 役テーブル ───────────────────────────── */

--- a/packages/client/src/ui/board.ts
+++ b/packages/client/src/ui/board.ts
@@ -97,6 +97,82 @@ function buildBoard(
   // ③ 自分エリア (下) - 手牌+ボタン
   board.appendChild(buildPlayerArea(state, onUpdate, onRestart, onNextRound, myPosition));
 
+  // 和了モーダル (独立したモーダル形式)
+  if (state.phase === 'agari') {
+    const info = state.agariInfo!;
+    const backdrop = document.createElement('div');
+    backdrop.className = 'agari-modal-backdrop';
+
+    const modal = document.createElement('div');
+    modal.className = 'agari-overlay';
+    const winnerName = state.playerNames?.[info.winner] ?? info.winner;
+    const agariType = info.isTsumo ? 'ツモ' : 'ロン';
+
+    const title = document.createElement('span');
+    title.className = 'agari-title';
+    title.textContent = '和　了';
+    modal.appendChild(title);
+
+    const winner = document.createElement('span');
+    winner.className = 'agari-winner';
+    winner.textContent = `${winnerName} の${agariType}`;
+    modal.appendChild(winner);
+
+    // 和了手牌
+    if (info.hand && info.hand.length > 0) {
+      const handRow = document.createElement('div');
+      handRow.className = 'agari-hand';
+      info.hand.forEach(t => {
+        const img = document.createElement('img');
+        img.src = getTileImagePath(t);
+        img.alt = getTileLabel(t);
+        img.draggable = false;
+        img.className = 'agari-hand__tile'
+          + (t.uid === info.tile.uid ? ' agari-hand__tile--winning' : '');
+        handRow.appendChild(img);
+      });
+      modal.appendChild(handRow);
+    }
+
+    // 役一覧
+    if (info.yakuList.length > 0) {
+      const yakuTable = document.createElement('div');
+      yakuTable.className = 'agari-yaku-table';
+      info.yakuList.forEach(y => {
+        const row = document.createElement('div');
+        row.className = 'agari-yaku-row';
+        row.innerHTML = `<span class="yaku-name">${y.name}</span><span class="yaku-han">${y.han}翻</span>`;
+        yakuTable.appendChild(row);
+      });
+      const total = document.createElement('div');
+      total.className = 'agari-yaku-total';
+      total.textContent = `${info.han}翻${info.fu}符`;
+      yakuTable.appendChild(total);
+      modal.appendChild(yakuTable);
+    }
+
+    // 点数
+    const score = document.createElement('span');
+    score.className = 'agari-score';
+    score.textContent = info.scoreDetail;
+    modal.appendChild(score);
+
+    // ボタン
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'btn btn--restart';
+    nextBtn.textContent = state.match.finished ? '結果を見る' : '次の局へ';
+    nextBtn.addEventListener('click', () => {
+      document.body.style.overflow = '';
+      onNextRound(state);
+    });
+    modal.appendChild(nextBtn);
+
+    backdrop.appendChild(modal);
+    board.appendChild(backdrop);
+    // モーダル表示中はページスクロールを無効化
+    document.body.style.overflow = 'hidden';
+  }
+
   return board;
 }
 
@@ -568,62 +644,6 @@ function buildPlayerArea(
   }
 
   area.appendChild(btnRow);
-
-  // 和了オーバーレイ
-  if (state.phase === 'agari') {
-    const info = state.agariInfo!;
-    const overlay = document.createElement('div');
-    overlay.className = 'agari-overlay';
-    const winnerName = state.playerNames?.[info.winner] ?? info.winner;
-    const agariType = info.isTsumo ? 'ツモ' : 'ロン';
-
-    const title = document.createElement('span');
-    title.className = 'agari-title';
-    title.textContent = '和　了';
-    overlay.appendChild(title);
-
-    const winner = document.createElement('span');
-    winner.className = 'agari-winner';
-    winner.textContent = `${winnerName} の${agariType}`;
-    overlay.appendChild(winner);
-
-    // 役一覧
-    if (info.yakuList.length > 0) {
-      const yakuTable = document.createElement('div');
-      yakuTable.className = 'agari-yaku-table';
-      info.yakuList.forEach(y => {
-        const row = document.createElement('div');
-        row.className = 'agari-yaku-row';
-        row.innerHTML = `<span class="yaku-name">${y.name}</span><span class="yaku-han">${y.han}翻</span>`;
-        yakuTable.appendChild(row);
-      });
-      // 合計
-      const total = document.createElement('div');
-      total.className = 'agari-yaku-total';
-      total.textContent = `${info.han}翻${info.fu}符`;
-      yakuTable.appendChild(total);
-      overlay.appendChild(yakuTable);
-    }
-
-    // 点数
-    const score = document.createElement('span');
-    score.className = 'agari-score';
-    score.textContent = info.scoreDetail;
-    overlay.appendChild(score);
-
-    // 半荘終了なら「終了画面へ」、通常は「次の局へ」
-    const nextBtn = document.createElement('button');
-    nextBtn.className = 'btn btn--restart';
-    if (state.match.finished) {
-      nextBtn.textContent = '結果を見る';
-      nextBtn.addEventListener('click', () => onNextRound(state));
-    } else {
-      nextBtn.textContent = '次の局へ';
-      nextBtn.addEventListener('click', () => onNextRound(state));
-    }
-    overlay.appendChild(nextBtn);
-    area.appendChild(overlay);
-  }
 
   // 流局オーバーレイ
   if (state.phase === 'ryukyoku') {

--- a/packages/server/src/actions.ts
+++ b/packages/server/src/actions.ts
@@ -173,6 +173,7 @@ export function declareTsumoAt(state: GameState, pos: Position): GameState {
       fu: scoreResult.fu,
       score: scoreResult.score,
       scoreDetail: scoreResult.scoreDetail,
+      hand,
     },
   };
 }
@@ -235,6 +236,7 @@ export function declareRonAt(state: GameState, pos: Position): GameState {
       fu: scoreResult.fu,
       score: scoreResult.score,
       scoreDetail: scoreResult.scoreDetail,
+      hand,
     },
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -47,6 +47,7 @@ export interface AgariInfo {
   fu: number;              // 符
   score: number;           // 獲得点数 (合計)
   scoreDetail: string;     // 表示用: "各XXXpt" or "XXXpt"
+  hand: Tile[];            // 和了時の手牌 (和了牌含む14枚)
 }
 
 // ─── 手番順序 ─────────────────────────────────────────


### PR DESCRIPTION
## 概要
issue #15「他プレイヤーがアガった際にアガり手を全プレイヤーに公開表示する」の実装。

## 変更内容

### 型定義 (`packages/shared/src/types.ts`)
- `AgariInfo` インターフェースに `hand: Tile[]`（和了牌含む14枚）を追加

### サーバー (`packages/server/src/actions.ts`)
- `declareTsumoAt()` / `declareRonAt()` の `agariInfo` に `hand` を設定

### クライアント state (`packages/client/src/game/state.ts`)
- `declareTsumo()` / `declareRon()` / `cpuDrawAndDiscard()` / `cpuDrawAndDiscardAt()` の `agariInfo` に `hand` を設定

### UI (`packages/client/src/ui/board.ts`)
- 和了オーバーレイを `buildPlayerArea()` から独立した**モーダル形式**に変更
  - `agari-modal-backdrop`（バックドロップ）→ `agari-overlay`（モーダル本体）の構造
  - バックドロップが `position: fixed` でビューポート全体を覆い、モーダル外のクリックを不可にする
  - モーダル表示中は `document.body.style.overflow = 'hidden'` でページスクロールを無効化
  - 和了手牌14枚を画像で横並び表示、和了牌をオレンジ色でハイライト

### スタイル (`packages/client/src/style.css`)
- `.agari-modal-backdrop` を新規追加（`rgba(80, 80, 80, 0.6)` の半透明グレー）
- `.agari-hand` / `.agari-hand__tile` / `.agari-hand__tile--winning` を追加

## 関連 issue
Closes #15